### PR TITLE
[WORK 🛠] 작업물 생성, 삭제

### DIFF
--- a/src/main/java/com/gam/api/controller/UserController.java
+++ b/src/main/java/com/gam/api/controller/UserController.java
@@ -1,0 +1,58 @@
+package com.gam.api.controller;
+
+import com.gam.api.common.ApiResponse;
+import com.gam.api.dto.user.UserInfoEditRequestDto;
+import com.gam.api.dto.user.UserScrapRequestDto;
+import com.gam.api.dto.user.UserScrapResponseDto;
+import com.gam.api.dto.user.UserInfoEditRequestDto;
+import com.gam.api.dto.user.UserInfoEditResponseDto;
+import com.gam.api.entity.User;
+import com.gam.api.entity.UserScrap;
+import com.gam.api.repository.UserRepository;
+import com.gam.api.service.UserService;
+import com.gam.api.service.UserServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
+import java.util.List;
+
+
+import static com.gam.api.common.ResponseMessage.SUCCESS_EDIT_USER_INFO;
+import static java.util.Objects.isNull;
+
+@Controller
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserServiceImpl userService;
+    private final UserRepository userRepository;
+    @PostMapping("/scrap")
+    ResponseEntity<ApiResponse> postUserScrap(Principal principal, @RequestBody UserScrapRequestDto request){
+        Long userId = getUser(principal);
+        UserScrapResponseDto response = userService.postUserScrap(userId, request);
+        if (response.userScrap()){
+            return ResponseEntity.ok(ApiResponse.success(SUCCESS_USER_SCRAP.getMessage(),response));
+        }return ResponseEntity.ok(ApiResponse.success(SUCCESS_USER_DELETE_SCRAP.getMessage(),response));
+    }
+
+
+    private Long getUser(Principal principal){
+        if (isNull(principal.getName()))
+            throw new IllegalArgumentException(NOT_FOUND_USER.getName());
+        return Long.valueOf(principal.getName());
+    }
+
+    @PatchMapping("/introduce")
+    ResponseEntity<ApiResponse> editUserInfo(Principal principal, @RequestBody UserInfoEditRequestDto request){
+        Long userId = getUser(principal);
+        UserInfoEditResponseDto response = userService.editUserInfo(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_EDIT_USER_INFO.getMessage(),response));
+    }
+}

--- a/src/main/java/com/gam/api/dto/user/UserInfoEditRequestDto.java
+++ b/src/main/java/com/gam/api/dto/user/UserInfoEditRequestDto.java
@@ -1,0 +1,10 @@
+package com.gam.api.dto.user;
+
+import java.util.ArrayList;
+
+public record UserInfoEditRequestDto(
+        String userInfo,
+        String userDetail,
+        ArrayList<String> tags
+) {
+}

--- a/src/main/java/com/gam/api/dto/user/UserInfoEditResponseDto.java
+++ b/src/main/java/com/gam/api/dto/user/UserInfoEditResponseDto.java
@@ -1,0 +1,26 @@
+package com.gam.api.dto.user;
+
+import lombok.Builder;
+
+import java.util.ArrayList;
+
+@Builder
+public record UserInfoEditResponseDto(
+        String userInfo,
+        String userDetail,
+        ArrayList<String> tags
+) {
+    public static UserInfoEditResponseDto of(
+            String userInfo,
+            String userDetail,
+            ArrayList<String> tags
+    ){
+        return UserInfoEditResponseDto
+                .builder()
+                .userInfo(userInfo)
+                .userDetail(userDetail)
+                .tags(tags)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -83,6 +83,8 @@ public class User {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+
 }
 
 

--- a/src/main/java/com/gam/api/entity/UserTag.java
+++ b/src/main/java/com/gam/api/entity/UserTag.java
@@ -1,10 +1,16 @@
 package com.gam.api.entity;
 
+import com.gam.api.common.ExceptionMessage;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -57,4 +63,62 @@ public class UserTag {
 
     @Column(name = "character")
     private boolean characterDesign;
+
+    @Builder
+    public UserTag(List<Boolean> booleanList){
+        int i = booleanList.size();
+        if (i != 12){
+            throw new RuntimeException(ExceptionMessage.CONFIG_ERROR.getName());
+        }
+        this.ui_uxDesign = booleanList.get(0);
+        this.bi_bxDesign = booleanList.get(1);
+        this.industrialDesign = booleanList.get(2);
+        this.threeDimensionalDesign = booleanList.get(3);
+        this.graphicDesign = booleanList.get(4);
+        this.packageDesign = booleanList.get(5);
+        this.motionDesign = booleanList.get(6);
+        this.IllustrationDesign = booleanList.get(7);
+        this.editDesign = booleanList.get(8);
+        this.fashionDesign = booleanList.get(9);
+        this.spaceDesign = booleanList.get(10);
+        this.characterDesign = booleanList.get(11);
+    }
+
+
+    public UserTag setUserTag(List<Boolean> booleanList){
+        int i = booleanList.size();
+        if (i != 12){
+            throw new RuntimeException(ExceptionMessage.CONFIG_ERROR.getName());
+        }
+        this.ui_uxDesign = booleanList.get(0);
+        this.bi_bxDesign = booleanList.get(1);
+        this.industrialDesign = booleanList.get(2);
+        this.threeDimensionalDesign = booleanList.get(3);
+        this.graphicDesign = booleanList.get(4);
+        this.packageDesign = booleanList.get(5);
+        this.motionDesign = booleanList.get(6);
+        this.IllustrationDesign = booleanList.get(7);
+        this.editDesign = booleanList.get(8);
+        this.fashionDesign = booleanList.get(9);
+        this.spaceDesign = booleanList.get(10);
+        this.characterDesign = booleanList.get(11);
+        return this;
+    }
+
+    public ArrayList<String> formattingUserTag(UserTag this){
+        ArrayList<String> result = new ArrayList<>();
+        if (this.ui_uxDesign == true) result.add("ui_ux");
+        if (this.ui_uxDesign == true) result.add("bi_bx");
+        if (this.industrialDesign == true) result.add("industrial");
+        if (this.threeDimensionalDesign == true) result.add("threeD");
+        if (this.graphicDesign == true) result.add("graphic");
+        if (this.packageDesign == true) result.add("package");
+        if (this.motionDesign == true) result.add("motion");
+        if (this.IllustrationDesign == true) result.add("Illustration");
+        if (this.editDesign == true) result.add("edit");
+        if (this.fashionDesign == true) result.add("fashion");
+        if (this.spaceDesign == true) result.add("space");
+        if (this.characterDesign == true) result.add("character");
+        return result;
+    }
 }

--- a/src/main/java/com/gam/api/repository/UserTagRepository.java
+++ b/src/main/java/com/gam/api/repository/UserTagRepository.java
@@ -1,0 +1,8 @@
+package com.gam.api.repository;
+
+import com.gam.api.entity.User;
+import com.gam.api.entity.UserTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTagRepository  extends JpaRepository<UserTag, Long> {
+}

--- a/src/main/java/com/gam/api/service/UserService.java
+++ b/src/main/java/com/gam/api/service/UserService.java
@@ -1,0 +1,12 @@
+package com.gam.api.service;
+
+import com.gam.api.dto.user.UserScrapRequestDto;
+import com.gam.api.dto.user.UserScrapResponseDto;
+
+import com.gam.api.dto.user.UserInfoEditRequestDto;
+import com.gam.api.dto.user.UserInfoEditResponseDto;
+
+public interface UserService {
+    UserScrapResponseDto postUserScrap(Long userId, UserScrapRequestDto request);
+    UserInfoEditResponseDto editUserInfo(Long userId, UserInfoEditRequestDto request);
+}

--- a/src/main/java/com/gam/api/service/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/UserServiceImpl.java
@@ -1,0 +1,101 @@
+package com.gam.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gam.api.dto.user.UserScrapRequestDto;
+import com.gam.api.dto.user.UserScrapResponseDto;
+import com.gam.api.common.ExceptionMessage;
+import com.gam.api.dto.user.UserInfoEditRequestDto;
+import com.gam.api.dto.user.UserInfoEditResponseDto;
+import com.gam.api.entity.User;
+import com.gam.api.entity.UserScrap;
+import com.gam.api.entity.UserTag;
+import com.gam.api.repository.UserRepository;
+import com.gam.api.repository.UserScrapRepository;
+import com.gam.api.repository.UserTagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.gam.api.common.message.ExceptionMessage.NOT_FOUND_USER;
+import static com.gam.api.common.message.ExceptionMessage.NOT_MATCH_DB_SCRAP_STATUS;
+
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserServiceImpl implements UserService {
+    private final UserScrapRepository userScrapRepository;
+    private final UserRepository userRepository;
+    private final UserTagRepository userTagRepository;
+
+    @Override
+    public UserScrapResponseDto postUserScrap(Long userId, UserScrapRequestDto request) {
+        User targetUser = userRepository.findById(request.targetUserId())
+                .orElseThrow(()-> new EntityNotFoundException(NOT_FOUND_USER.getName()));
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new EntityNotFoundException(NOT_FOUND_USER.getName()));
+
+        Optional<UserScrap> userScrap = userScrapRepository.findByUserScrap_idAndTargetId(userId, targetUser.getId());
+        if (userScrap.isPresent()) {
+            chkClientAndDBStatus(userScrap.get().isStatus(), request.currentScrapStatus());
+
+            if (userScrap.get().isStatus() == true) targetUser.scrapCountDown();
+            else targetUser.scrapCountUp();
+
+            userScrap.get().setScrapStatus(!userScrap.get().isStatus());
+
+            return UserScrapResponseDto.of(targetUser.getId(), targetUser.getUserName(), userScrap.get().isStatus());
+        }
+        createUserScrap(user, targetUser.getId(), targetUser);
+        return UserScrapResponseDto.of(targetUser.getId(), targetUser.getUserName(), true);
+    }
+    private void createUserScrap(User user, Long targetId, User targetUser){
+        userScrapRepository.save(
+                UserScrap.builder()
+                        .userScrap(user)
+                        .targetId(targetId)
+                        .build());
+        targetUser.scrapCountUp();
+    }
+    private void chkClientAndDBStatus(boolean requestStatus, boolean DBStatus){
+        if (requestStatus!=DBStatus){
+            throw new IllegalArgumentException(NOT_MATCH_DB_SCRAP_STATUS.getName());
+        }
+    }
+
+    @Override
+    public UserInfoEditResponseDto editUserInfo(Long userId, UserInfoEditRequestDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getName()));
+        if (request.userInfo() != null) user.setInfo(request.userInfo());
+
+        if (request.userDetail() != null) user.setDetail(request.userDetail());
+
+        if (request.tags()!=null){
+            List<Boolean> skeletonStatus = new ArrayList<>(Arrays.asList(false,false,false,false,false,false,false,false,false,false,false,false));
+            List<String> skeletonTag = new ArrayList<>(Arrays.asList("ui_ux", "bi_bx", "industrial", "threeD", "graphic", "package", "motion", "Illustration", "edit", "fashion", "space", "character"));
+
+            for(String tag: request.tags()){
+                int index = skeletonTag.indexOf(tag);
+                if (index==-1) throw new IllegalArgumentException(ExceptionMessage.BAD_REQUEST.getName());
+                skeletonStatus.set(index,true);
+            }
+
+            UserTag userTag = user.getUserTag();
+            userTag.setUserTag(skeletonStatus);
+            userTagRepository.save(userTag);
+            user.setUserTag(userTag);
+        }
+
+        userRepository.save(user);
+        return UserInfoEditResponseDto.of(user.getInfo(),user.getDetail(),user.getUserTag().formattingUserTag());
+    }
+
+}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #4 

## Work Description ✏️
- 마이페이지 자기소개 수정했습니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 유저 스크랩중에 tag가 까다로웠습니다.. 사용자가 보내준 값만 true로 하고, 나머지를 다 false로 바꿧는데, 저는 skeleton코드를 사용했습니다.
-> 만약 이 방법을 계속 사용한다면, 차후에 엔티티의 필드값들을 string으로 바꿀 수 있는 것을 참고하여 리팩토링 하면 좋을 것 같습니다.
-> 스켈레톤 코드 자체를 사용 하지 않는 방법이 제일 베스트 같긴 한데, 떠오르지 않습니다..흑

- userScrap의 dto값을 return 할때도,, 엄청나게.. 지저분한 메서드를 userScrap에 만들어서 formatting했는데, 적당한 방법이 떠오르지 않았습니다. . 같이 고쳐보면 좋을 것 같습니다.

- 건의사항
- userScrap에 대하여, 전반적인 구조를 바꾸는것도 방법인 것 같습니다. 같이 얘기해봐요.! 
