### PR TITLE
[WORK 🛠] 유저 - 대표작업물로 설정

### DIFF
--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -27,6 +27,7 @@ public enum ExceptionMessage {
     /** Work **/
     WORK_COUNT_EXCEED("올릴 수 있는 작업물 개수를 초과했습니다."),
     NOT_FOUND_WORK("해당하는 작업을 찾을 수 없습니다."),
+    ALREADY_FIRST_WORK("이미 대표 게시글 입니다."),
     NOT_WORK_OWNER("작업물의 주인이 아닙니다.");
 
     private final String message;

--- a/src/main/java/com/gam/api/common/message/ResponseMessage.java
+++ b/src/main/java/com/gam/api/common/message/ResponseMessage.java
@@ -26,7 +26,8 @@ public enum ResponseMessage {
 
     /** work **/
     SUCCESS_CREATE_WORK("작업물 생성 성공"),
-    SUCCESS_DELETE_WORK("작업물 삭제 성공");
+    SUCCESS_DELETE_WORK("작업물 삭제 성공"),
+    SUCCESS_UPDATE_FIRST_WORK("대표 작업물 설정 성공");
 
     private final String message;
 }

--- a/src/main/java/com/gam/api/controller/WorkController.java
+++ b/src/main/java/com/gam/api/controller/WorkController.java
@@ -4,6 +4,7 @@ import com.gam.api.common.util.AuthCommon;
 import com.gam.api.common.message.ResponseMessage;
 import com.gam.api.dto.work.request.WorkCreateRequestDTO;
 import com.gam.api.dto.work.request.WorkDeleteRequestDTO;
+import com.gam.api.dto.work.request.WorkFirstAssignRequestDto;
 import com.gam.api.service.work.WorkService;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -32,5 +33,12 @@ public class WorkController {
         val userId = AuthCommon.getUser(principal);
         val response = workService.deleteWork(userId, request);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_DELETE_WORK.getMessage(), response));
+    }
+
+    @PatchMapping("main")
+    public ResponseEntity<ApiResponse> updateFirstWork(Principal principal, @RequestBody WorkFirstAssignRequestDto request){
+        val userId = AuthCommon.getUser(principal);
+        workService.updateFirstWork(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_UPDATE_FIRST_WORK.getMessage()));
     }
 }

--- a/src/main/java/com/gam/api/controller/WorkController.java
+++ b/src/main/java/com/gam/api/controller/WorkController.java
@@ -35,7 +35,7 @@ public class WorkController {
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_DELETE_WORK.getMessage(), response));
     }
 
-    @PatchMapping("main")
+    @PatchMapping("/main")
     public ResponseEntity<ApiResponse> updateFirstWork(Principal principal, @RequestBody WorkFirstAssignRequestDto request){
         val userId = AuthCommon.getUser(principal);
         workService.updateFirstWork(userId, request);

--- a/src/main/java/com/gam/api/dto/work/request/WorkFirstAssignRequestDto.java
+++ b/src/main/java/com/gam/api/dto/work/request/WorkFirstAssignRequestDto.java
@@ -1,0 +1,6 @@
+package com.gam.api.dto.work.request;
+
+public record WorkFirstAssignRequestDto (
+        Long workId
+){
+}

--- a/src/main/java/com/gam/api/entity/Work.java
+++ b/src/main/java/com/gam/api/entity/Work.java
@@ -69,4 +69,8 @@ public class Work extends TimeStamped {
         this.user = user;
         user.getWorks().add(this);
     }
+
+    public void setIsFirst(boolean status){
+        this.isFirst = status;
+    }
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -1,14 +1,12 @@
 package com.gam.api.repository;
 
-import com.gam.api.entity.User;
 import com.gam.api.entity.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface WorkRepository extends JpaRepository<Work, Long> {
     Optional<Work> getWorkById(Long workId);
     void deleteById(Long workId);
-    Optional<Work> getWorkByIsFirst(Boolean status);
+    Optional<Work> getWorkByUserIdAndIsFirst(Long userId, Boolean status);
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -3,10 +3,12 @@ package com.gam.api.repository;
 import com.gam.api.entity.User;
 import com.gam.api.entity.Work;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface WorkRepository extends JpaRepository<Work, Long> {
     Optional<Work> getWorkById(Long workId);
     void deleteById(Long workId);
+    Optional<Work> getWorkByIsFirst(Boolean status);
 }

--- a/src/main/java/com/gam/api/service/work/WorkService.java
+++ b/src/main/java/com/gam/api/service/work/WorkService.java
@@ -2,9 +2,11 @@ package com.gam.api.service.work;
 
 import com.gam.api.dto.work.request.WorkCreateRequestDTO;
 import com.gam.api.dto.work.request.WorkDeleteRequestDTO;
+import com.gam.api.dto.work.request.WorkFirstAssignRequestDto;
 import com.gam.api.dto.work.response.WorkResponseDTO;
 
 public interface WorkService {
     WorkResponseDTO createWork(Long userId, WorkCreateRequestDTO request);
     WorkResponseDTO deleteWork(Long userId, WorkDeleteRequestDTO request);
+    void updateFirstWork(Long userId, WorkFirstAssignRequestDto request);
 }

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -66,6 +66,7 @@ public class WorkServiceImpl implements WorkService {
         return WorkResponseDTO.of(workId);
     }
 
+    @Override
     @Transactional
     public void updateFirstWork(Long userId, WorkFirstAssignRequestDto request){
         val workId = request.workId();

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -77,7 +77,7 @@ public class WorkServiceImpl implements WorkService {
             throw new IllegalArgumentException(ExceptionMessage.ALREADY_FIRST_WORK.getMessage());
         }
 
-        val pastFirstWork = workRepository.getWorkByIsFirst(true);
+        val pastFirstWork = workRepository.getWorkByUserIdAndIsFirst(userId, true);
 
         if (pastFirstWork.isPresent()){
             pastFirstWork.get().setIsFirst(false);

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -4,6 +4,7 @@ import com.gam.api.common.exception.WorkException;
 import com.gam.api.common.message.ExceptionMessage;
 import com.gam.api.dto.work.request.WorkCreateRequestDTO;
 import com.gam.api.dto.work.request.WorkDeleteRequestDTO;
+import com.gam.api.dto.work.request.WorkFirstAssignRequestDto;
 import com.gam.api.dto.work.response.WorkResponseDTO;
 import com.gam.api.entity.Work;
 import com.gam.api.repository.UserRepository;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -62,5 +64,24 @@ public class WorkServiceImpl implements WorkService {
         workRepository.deleteById(workId);
 
         return WorkResponseDTO.of(workId);
+    }
+
+    @Transactional
+    public void updateFirstWork(Long userId, WorkFirstAssignRequestDto request){
+        val workId = request.workId();
+
+        val currentWork = workRepository.getWorkById(workId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
+
+        if (currentWork.isFirst()){
+            throw new IllegalArgumentException(ExceptionMessage.ALREADY_FIRST_WORK.getMessage());
+        }
+
+        val pastFirstWork = workRepository.getWorkByIsFirst(true);
+
+        if (pastFirstWork.isPresent()){
+            pastFirstWork.get().setIsFirst(false);
+        }
+        currentWork.setIsFirst(true);
     }
 }

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -83,5 +83,10 @@ public class WorkServiceImpl implements WorkService {
             pastFirstWork.get().setIsFirst(false);
         }
         currentWork.setIsFirst(true);
+
+        val user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
+
+        user.setWorkThumbNail(currentWork.getPhotoUrl());
     }
 }


### PR DESCRIPTION
## Related Issue 🚀
- #23 

## Work Description ✏️
- 유저 대표작업물 설정 api개발 

## PR Point 📸
- DB update를 최소화 하기 위해 이미 대표로 설정된 work일 경우에 가장 먼저 exception을 날려주었습니다.
 -> 상태코드를 몇번으로 줘야할 지 아직 미정이라, 같이 얘기해보면 좋을 것 같아요!
- DB update를 최소화 하기 위해 가장  처음으로 대표로 설정한 경우가 아닐때만 (pastFirstWork가 있을 경우) pastWork의 상태를 바꿔줬습니다.
- user의 thumbNail도 변경 완료했쩌요~