### PR TITLE
[WORK🛠] 검색 API 소문자 검색 추가

### DIFF
--- a/src/main/java/com/gam/api/dto/search/response/SearchUserWorkDTO.java
+++ b/src/main/java/com/gam/api/dto/search/response/SearchUserWorkDTO.java
@@ -13,6 +13,7 @@ public record SearchUserWorkDTO(
     public static SearchUserWorkDTO of (Work work) {
         return SearchUserWorkDTO.builder()
                 .thumbNail(work.getPhotoUrl())
+                .title(work.getTitle())
                 .userName(work.getUser().getUserName())
                 .viewCount(work.getViewCount())
                 .build();

--- a/src/main/java/com/gam/api/repository/MagazineRepository.java
+++ b/src/main/java/com/gam/api/repository/MagazineRepository.java
@@ -12,6 +12,11 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> getMagazineById(Long magazineId);
     List<Magazine> findTop4ByOrderByCreatedAtDesc();
     List<Magazine> findTop3ByOrderByViewCountDesc();
-    @Query(value = "SELECT m FROM Magazine  m WHERE m.interviewPerson LIKE %:keyword% OR m.magazineTitle LIKE %:keyword% ORDER BY m.createdAt DESC")
-    List<Magazine> findAllSearch(@Param("keyword") String keyword);
+    List<Magazine> findAllByInterviewPersonContainingIgnoreCaseOrMagazineTitleContainingIgnoreCaseOrderByCreatedAtDesc(String userNameKeyWord, String titleNameKeyWord);
+    @Query("SELECT m FROM Magazine m WHERE LOWER(m.interviewPerson) LIKE %:interviewPersonKeyword% OR LOWER(m.magazineTitle) LIKE %:magazineTitleKeyword% ORDER BY m.createdAt DESC")
+    List<Magazine> finAllByKeyword(
+            @Param("interviewPersonKeyword") String userNameKeyWord,
+            @Param("magazineTitleKeyword") String titleNameKeyWord
+    );
 }
+

--- a/src/main/java/com/gam/api/repository/MagazineRepository.java
+++ b/src/main/java/com/gam/api/repository/MagazineRepository.java
@@ -12,7 +12,6 @@ public interface MagazineRepository extends JpaRepository<Magazine, Long> {
     Optional<Magazine> getMagazineById(Long magazineId);
     List<Magazine> findTop4ByOrderByCreatedAtDesc();
     List<Magazine> findTop3ByOrderByViewCountDesc();
-    List<Magazine> findAllByInterviewPersonContainingIgnoreCaseOrMagazineTitleContainingIgnoreCaseOrderByCreatedAtDesc(String userNameKeyWord, String titleNameKeyWord);
     @Query("SELECT m FROM Magazine m WHERE LOWER(m.interviewPerson) LIKE %:interviewPersonKeyword% OR LOWER(m.magazineTitle) LIKE %:magazineTitleKeyword% ORDER BY m.createdAt DESC")
     List<Magazine> finAllByKeyword(
             @Param("interviewPersonKeyword") String userNameKeyWord,

--- a/src/main/java/com/gam/api/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/repository/UserRepository.java
@@ -14,6 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUserName(String userName);
     List<User> findTop5ByOrderByScrapCountDesc();
     List<User> findAllByIdNotOrderBySelectedFirstAtDesc(Long id);
-    @Query(value = "SELECT u FROM User u WHERE u.userName LIKE %:keyword% ORDER BY u.createdAt DESC")
+    @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")
     List<User> findByUserName(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/gam/api/repository/UserTagRepository.java
+++ b/src/main/java/com/gam/api/repository/UserTagRepository.java
@@ -8,8 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface UserTagRepository extends JpaRepository<UserTag, Long> {
-    @EntityGraph(attributePaths = "tag")
-    List<UserTag> findAllByUser_Id(Long userId);
-
     void deleteAllByUser_id(Long userId);
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -13,6 +13,6 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     Optional<Work> getWorkByUserIdAndIsFirst(Long userId, Boolean status);
     List<Work> findByUserIdAndIsFirstOrderByCreatedAtDesc(Long userId, boolean isFirst);
     List<Work> findByUserId(Long userId);
-    @Query(value = "SELECT w FROM Work w WHERE w.title LIKE %:keyword% ORDER BY w.createdAt DESC")
+    @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE %:keyword% ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
 }

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -37,10 +37,11 @@ public class MagazineServiceImpl implements MagazineService {
         return MagazineResponseDTO.of(magazineList, magazineScrapList);
     }
 
+    @Transactional
     @Override
     public MagazineDetailResponseDTO getMagazineDetail(Long magazineId) {
         val magazine = getMagazine(magazineId);
-        magazine.setViewCount(magazine.getViewCount()+1);
+        magazine.setViewCount(magazine.getViewCount() + 1);
         return MagazineDetailResponseDTO.of(magazine);
     }
 

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -40,6 +40,7 @@ public class MagazineServiceImpl implements MagazineService {
     @Override
     public MagazineDetailResponseDTO getMagazineDetail(Long magazineId) {
         val magazine = getMagazine(magazineId);
+        magazine.setViewCount(magazine.getViewCount()+1);
         return MagazineDetailResponseDTO.of(magazine);
     }
 

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -103,7 +103,7 @@ public class MagazineServiceImpl implements MagazineService {
 
     @Override
     public List<MagazineSearchResponseDTO> searchMagazine(String keyword) {
-        val magazines = magazineRepository.findAllSearch(keyword);
+        val magazines = magazineRepository.finAllByKeyword(keyword, keyword);
         return magazines.stream()
                 .map((magazine) -> MagazineSearchResponseDTO.of(magazine))
                 .collect(Collectors.toList());

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -214,8 +214,7 @@ public class UserServiceImpl implements UserService {
     public WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId) {
         val requestUser = findUser(requestUserId);
         val user = findUser(userId);
-        user.setViewCount(user.getViewCount()+1);
-//        userRepository.save(user);
+        user.setViewCount(user.getViewCount() +1 );
         val works = getUserPortfolio(userId);
 
         val scrapList = requestUser.getUserScraps().stream()

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -209,10 +209,13 @@ public class UserServiceImpl implements UserService {
     }
 
 
+    @Transactional
     @Override
     public WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId) {
         val requestUser = findUser(requestUserId);
         val user = findUser(userId);
+        user.setViewCount(user.getViewCount()+1);
+//        userRepository.save(user);
         val works = getUserPortfolio(userId);
 
         val scrapList = requestUser.getUserScraps().stream()

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -214,7 +214,7 @@ public class UserServiceImpl implements UserService {
     public WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId) {
         val requestUser = findUser(requestUserId);
         val user = findUser(userId);
-        user.setViewCount(user.getViewCount() +1 );
+        user.setViewCount(user.getViewCount() +1);
         val works = getUserPortfolio(userId);
 
         val scrapList = requestUser.getUserScraps().stream()


### PR DESCRIPTION
## Related Issue 🚀
- #67 

## Work Description ✏️
- 매거진 검색, (유저이름 + 작업물 제목) 검색  API에 소문자 포함 검색을 추가했습니다. 모두, 대소문자 구분 없이 검색이 잘 ~ 됩니다.
* 참고 : 유저 이름도 대소문자 구분 없이 검색 할 수 있습니다. 
- 유저 , 매거진을 GET할 시에 viewCount +=1를 진행합니다.

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 대소문자 구분없이 메소드명으로 Spring Data Jpa를 작성하는 방법과 , @Query를 이용해서 작성하는 방법 모두 Pr 브랜치에 코딩한 상태입니다.
제가 보기에는 @Query를 사용한 메소드가 나을 것 같아, 현재로서는 @Query를 적용한 매소드로 search로직들을 처리중입니다.

   뭐가 나은지 말씀 편하게 해주시고, 머지할 때 하나만 선택하여 develop에 머지하겠습니다!

   웹까지 개발하느라 고생 정말 많습니다 용택리~ 멋져요 진짜 
