### PR TITLE
[WORK🛠] 리프레시, 로그아웃 with redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	// postgers int[] 관련
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-5:3.5.0'
 
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gam/api/common/ErrorHandler.java
+++ b/src/main/java/com/gam/api/common/ErrorHandler.java
@@ -1,6 +1,9 @@
 package com.gam.api.common;
 
 
+import com.gam.api.common.exception.AuthException;
+import com.gam.api.common.exception.AwsException;
+import com.gam.api.common.exception.WorkException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -29,6 +32,24 @@ public class ErrorHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception){
         ApiResponse response = ApiResponse.fail(EMPTY_METHOD_ARGUMENT.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ApiResponse> authException(AuthException exception){
+        ApiResponse response = ApiResponse.fail(exception.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(AwsException.class)
+    public ResponseEntity<ApiResponse> awsException(AwsException exception){
+        ApiResponse response = ApiResponse.fail(exception.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(WorkException.class)
+    public ResponseEntity<ApiResponse> workException(WorkException exception){
+        ApiResponse response = ApiResponse.fail(exception.getMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -12,6 +12,9 @@ public enum ExceptionMessage {
     EXPIRED_TOKEN("만료된 토큰입니다."),
     INVALID_SIGNATURE("유효하지 않은 서명입니다."),
     PROFILE_UNCOMPLETED_USER("마이페이지를 작성하지 않은 유저입니다."),
+    INVALID_REFRESH_TOKEN("잘못된 리프레시 토큰입니다."),
+    KAKAO_CODE_ERROR("유효하지 않은 코드입니다"),
+    ALREADY_LOGOUT_TOKEN("이미 로그아웃된 토큰입니다"),
 
     /** exception **/
     EMPTY_METHOD_ARGUMENT("빈 요청값이 있습니다."),

--- a/src/main/java/com/gam/api/common/message/ResponseMessage.java
+++ b/src/main/java/com/gam/api/common/message/ResponseMessage.java
@@ -9,7 +9,8 @@ public enum ResponseMessage {
 
     /** auth **/
     SUCCESS_SIGN_UP("회원 가입 성공"),
-    SUCCESS_LOGIN_UP("로그인 성공"),
+    SUCCESS_LOGIN("로그인 성공"),
+    SUCCESS_LOGOUT("로그아웃 성공"),
     SUCCESS_GET_REFRESH_TOKEN("토큰 재발급 성공"),
 
 

--- a/src/main/java/com/gam/api/common/util/RedisUtil.java
+++ b/src/main/java/com/gam/api/common/util/RedisUtil.java
@@ -1,0 +1,35 @@
+package com.gam.api.common.util;
+
+import lombok.val;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+public class RedisUtil {
+    public static void saveBlackList(RedisTemplate<String, Object> redisTemplate, String blackListToken, Long userId, Long accessRemainTime) {
+        val redisKey = "blacklist:user:" + userId + ":" + blackListToken;
+
+        redisTemplate.opsForValue().set(redisKey, "true", accessRemainTime, TimeUnit.SECONDS);
+    }
+
+    public static void saveRefreshToken(RedisTemplate<String, Object> redisTemplate, String refreshToken, Long userId) {
+        val redisKey = "refresh:user:" + userId;
+
+        redisTemplate.opsForValue().set(redisKey, refreshToken, 14, TimeUnit.DAYS);
+    }
+
+    public static boolean checkBlackListExist(RedisTemplate<String, Object> redisTemplate, Long userId, String accessToken) {
+        val redisKey = "blacklist:user:" + userId + ":" + accessToken;
+        return !Objects.isNull(redisTemplate.opsForValue().get(redisKey));
+    }
+
+    public static Object getRefreshToken(RedisTemplate<String, Object> redisTemplate, Long userId) {
+        val redisKey = "refresh:user:" + userId;
+        return redisTemplate.opsForValue().get(redisKey);
+    }
+
+    public static void deleteKey(RedisTemplate<String, Object> redisTemplate, String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/gam/api/config/RedisConfig.java
+++ b/src/main/java/com/gam/api/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.gam.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Value("${redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/gam/api/config/jwt/JwtTokenManager.java
+++ b/src/main/java/com/gam/api/config/jwt/JwtTokenManager.java
@@ -2,6 +2,7 @@ package com.gam.api.config.jwt;
 
 import com.gam.api.common.exception.AuthException;
 import com.gam.api.common.message.ExceptionMessage;
+import com.gam.api.common.util.RedisUtil;
 import com.gam.api.config.AuthConfig;
 import com.gam.api.service.user.UserDetailsServiceImpl;
 import io.jsonwebtoken.Claims;
@@ -11,12 +12,15 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
+import java.time.Duration;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
 @RequiredArgsConstructor
@@ -27,13 +31,13 @@ public class JwtTokenManager {
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UserDetailsServiceImpl userDetailsService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public String createAccessToken(Long userId) {
         val signatureAlgorithm = SignatureAlgorithm.HS256;
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(authConfig.getJwtSecretKey());
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
-        val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusHours(6).atZone(KST).toInstant();
+        val exp = ZonedDateTime.now(KST).toLocalDateTime().plusHours(6).atZone(KST).toInstant();
 
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
@@ -46,8 +50,7 @@ public class JwtTokenManager {
         val signatureAlgorithm = SignatureAlgorithm.HS256;
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(authConfig.getJwtSecretKey());
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
-        val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusDays(7).atZone(KST).toInstant();
+        val exp = ZonedDateTime.now(KST).toLocalDateTime().plusDays(14).atZone(KST).toInstant();
 
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
@@ -77,8 +80,22 @@ public class JwtTokenManager {
 
     public AdminAuthentication getAuthentication(String token) {
         val userId = getUserIdFromAuthToken(token);
+
+        if (RedisUtil.checkBlackListExist(redisTemplate, Long.parseLong(userId), token)) {
+            throw new AuthException(ExceptionMessage.INVALID_TOKEN.getMessage(),HttpStatus.BAD_REQUEST);
+        }
+
         val userDetails = userDetailsService.loadUserByUsername(userId);
         return new AdminAuthentication(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+    }
+
+    public long getAccessTokenExpirationRemainder(String accessToken) {
+        val claims = getClaimsFromToken(accessToken);
+
+        val expirationTimestamp = claims.getExpiration().toInstant();
+        val currentTimestamp = ZonedDateTime.now(KST).toInstant();
+
+        return Duration.between(currentTimestamp, expirationTimestamp).toMillis();
     }
 
     private Claims getClaimsFromToken (String token) throws SignatureException {

--- a/src/main/java/com/gam/api/controller/SocialController.java
+++ b/src/main/java/com/gam/api/controller/SocialController.java
@@ -1,6 +1,9 @@
 package com.gam.api.controller;
 
 import com.gam.api.common.message.ResponseMessage;
+import com.gam.api.dto.social.request.SocialLogoutRequestDTO;
+import com.gam.api.dto.social.request.SocialRefreshRequestDTO;
+import com.gam.api.service.social.SocialCommonService;
 import com.gam.api.service.social.SocialServiceProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -14,11 +17,24 @@ import com.gam.api.dto.social.request.SocialLoginRequestDTO;
 @RequestMapping("api/v1/social")
 public class SocialController {
     private final SocialServiceProvider socialServiceProvider;
+    private final SocialCommonService socialCommonService;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse> login(@RequestBody SocialLoginRequestDTO request) {
         val socialService = socialServiceProvider.getSocialService(request.providerType());
         val response = socialService.login(request);
-        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_LOGIN_UP.getMessage(), response));
+        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_LOGIN.getMessage(), response));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse> login(@RequestBody SocialLogoutRequestDTO request) {
+        socialCommonService.logout(request);
+        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_LOGOUT.getMessage()));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse> login(@RequestBody SocialRefreshRequestDTO request) {
+        val response = socialCommonService.refresh(request);
+        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_GET_REFRESH_TOKEN.getMessage(), response));
     }
 }

--- a/src/main/java/com/gam/api/dto/social/request/SocialLogoutRequestDTO.java
+++ b/src/main/java/com/gam/api/dto/social/request/SocialLogoutRequestDTO.java
@@ -1,0 +1,7 @@
+package com.gam.api.dto.social.request;
+
+public record SocialLogoutRequestDTO(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/gam/api/dto/social/request/SocialRefreshRequestDTO.java
+++ b/src/main/java/com/gam/api/dto/social/request/SocialRefreshRequestDTO.java
@@ -1,0 +1,7 @@
+package com.gam.api.dto.social.request;
+
+public record SocialRefreshRequestDTO(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/gam/api/dto/social/response/SocialLoginResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/social/response/SocialLoginResponseDTO.java
@@ -3,13 +3,14 @@ package com.gam.api.dto.social.response;
 import lombok.Builder;
 
 @Builder
-public record SocialLoginResponseDTO(Boolean isUser, Boolean isProfileCompleted, Long id, String accessToken, String appVersion) {
-    public static SocialLoginResponseDTO of(Boolean isUser,  Boolean isProfileCompleted, Long id, String accessToken, String appVersion) {
+public record SocialLoginResponseDTO(Boolean isUser, Boolean isProfileCompleted, Long id, String accessToken, String refreshToken, String appVersion) {
+    public static SocialLoginResponseDTO of(Boolean isUser,  Boolean isProfileCompleted, Long id, String accessToken, String refreshToken, String appVersion) {
         return SocialLoginResponseDTO.builder()
                 .isUser(isUser)
                 .isProfileCompleted(isProfileCompleted)
                 .id(id)
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .appVersion(appVersion)
                 .build();
     }

--- a/src/main/java/com/gam/api/dto/social/response/SocialRefreshResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/social/response/SocialRefreshResponseDTO.java
@@ -1,0 +1,16 @@
+package com.gam.api.dto.social.response;
+
+import lombok.Builder;
+
+@Builder
+public record SocialRefreshResponseDTO(
+        String accessToken,
+        String refreshToken
+) {
+    public static SocialRefreshResponseDTO of(String accessToken, String refreshToken) {
+        return SocialRefreshResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -68,9 +68,6 @@ public class User extends TimeStamped {
     @Column(name = "view_count")
     private int viewCount;
 
-    @Column(name = "refresh_token")
-    private String refreshToken;
-
     @Column(name = "work_thumb_nail")
     private String workThumbNail;
 
@@ -114,10 +111,6 @@ public class User extends TimeStamped {
         this.userStatus = userStatus;
         this.scrapCount = 0;
         this.viewCount = 0;
-    }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
     }
 
     public void updateUserStatus(UserStatus userStatus) {

--- a/src/main/java/com/gam/api/service/social/KakaoSocialService.java
+++ b/src/main/java/com/gam/api/service/social/KakaoSocialService.java
@@ -1,8 +1,12 @@
 package com.gam.api.service.social;
 
+import com.gam.api.common.exception.AuthException;
+import com.gam.api.common.message.ExceptionMessage;
+import com.gam.api.common.util.RedisUtil;
 import com.gam.api.config.AuthConfig;
 import com.gam.api.config.GamConfig;
 import com.gam.api.config.jwt.JwtTokenManager;
+import com.gam.api.dto.kakao.KakaoAccessTokenResponse;
 import com.gam.api.dto.social.response.SocialLoginResponseDTO;
 import com.gam.api.entity.AuthProvider;
 import com.gam.api.entity.Role;
@@ -12,6 +16,8 @@ import com.gam.api.repository.AuthProviderRepository;
 import com.gam.api.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import com.gam.api.external.kakao.KakaoApiClient;
 import com.gam.api.external.kakao.KakaoAuthApiClient;
@@ -34,15 +40,22 @@ public class KakaoSocialService implements SocialService {
     private final AuthConfig authConfig;
     private final GamConfig gamConfig;
 
+    private final RedisTemplate<String, Object> redisTemplate;
+
     @Override
     @Transactional
     public SocialLoginResponseDTO login(SocialLoginRequestDTO request) {
-        val kakaoAccessTokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
-                "authorization_code",
-                authConfig.getKakaoClientSecret(),
-                authConfig.getKakaoRedirectUri(),
-                request.code()
-        );
+        KakaoAccessTokenResponse kakaoAccessTokenResponse;
+        try {
+            kakaoAccessTokenResponse = kakaoAuthApiClient.getOAuth2AccessToken(
+                    "authorization_code",
+                    authConfig.getKakaoClientSecret(),
+                    authConfig.getKakaoRedirectUri(),
+                    request.code()
+            );
+        } catch (RuntimeException e) {
+            throw new AuthException(ExceptionMessage.KAKAO_CODE_ERROR.getMessage(), HttpStatus.BAD_REQUEST);
+        }
 
         val userResponse = kakaoApiClient.getUserInformation("Bearer " + kakaoAccessTokenResponse.getAccessToken());
 
@@ -54,7 +67,7 @@ public class KakaoSocialService implements SocialService {
             val accessToken = jwtTokenManager.createAccessToken(userId);
             val refreshToken = jwtTokenManager.createRefreshToken(userId);
 
-            user.updateRefreshToken(refreshToken);
+            RedisUtil.saveRefreshToken(redisTemplate, refreshToken, userId);
 
             val isProfileCompleted = chkProfileCompleted(user);
             return SocialLoginResponseDTO.of(true, isProfileCompleted, userId, accessToken, gamConfig.getAppVersion());
@@ -69,7 +82,7 @@ public class KakaoSocialService implements SocialService {
         val accessToken = jwtTokenManager.createAccessToken(userId);
         val refreshToken = jwtTokenManager.createRefreshToken(userId);
 
-        user.updateRefreshToken(refreshToken);
+        RedisUtil.saveRefreshToken(redisTemplate, refreshToken, userId);
 
         authProviderRepository.save(AuthProvider.builder()
                         .id(userResponse.id())
@@ -81,15 +94,7 @@ public class KakaoSocialService implements SocialService {
     }
 
     @Override
-    public void logout(Long userId) {
-
-    }
-
-    @Override
     public boolean chkProfileCompleted(User user) {
-        if(Objects.isNull(user.getInfo()) || Objects.isNull(user.getUserTag())) {
-            return false;
-        }
-        return true;
+        return !Objects.isNull(user.getInfo()) && !Objects.isNull(user.getUserTag());
     }
 }

--- a/src/main/java/com/gam/api/service/social/KakaoSocialService.java
+++ b/src/main/java/com/gam/api/service/social/KakaoSocialService.java
@@ -70,7 +70,7 @@ public class KakaoSocialService implements SocialService {
             RedisUtil.saveRefreshToken(redisTemplate, refreshToken, userId);
 
             val isProfileCompleted = chkProfileCompleted(user);
-            return SocialLoginResponseDTO.of(true, isProfileCompleted, userId, accessToken, gamConfig.getAppVersion());
+            return SocialLoginResponseDTO.of(true, isProfileCompleted, userId, accessToken, refreshToken, gamConfig.getAppVersion());
         }
 
         val user = userRepository.save(User.builder()
@@ -90,7 +90,7 @@ public class KakaoSocialService implements SocialService {
                         .providerType(request.providerType())
                         .build());
 
-        return SocialLoginResponseDTO.of(false, false, userId, accessToken, gamConfig.getAppVersion());
+        return SocialLoginResponseDTO.of(false, false, userId, accessToken, refreshToken, gamConfig.getAppVersion());
     }
 
     @Override

--- a/src/main/java/com/gam/api/service/social/SocialCommonService.java
+++ b/src/main/java/com/gam/api/service/social/SocialCommonService.java
@@ -1,0 +1,11 @@
+package com.gam.api.service.social;
+
+import com.gam.api.dto.social.request.SocialLogoutRequestDTO;
+import com.gam.api.dto.social.request.SocialRefreshRequestDTO;
+import com.gam.api.dto.social.response.SocialRefreshResponseDTO;
+
+public interface SocialCommonService {
+    void logout(SocialLogoutRequestDTO request);
+
+    SocialRefreshResponseDTO refresh(SocialRefreshRequestDTO request);
+}

--- a/src/main/java/com/gam/api/service/social/SocialCommonServiceImpl.java
+++ b/src/main/java/com/gam/api/service/social/SocialCommonServiceImpl.java
@@ -1,0 +1,81 @@
+package com.gam.api.service.social;
+
+import com.gam.api.common.message.ExceptionMessage;
+import com.gam.api.common.exception.AuthException;
+import com.gam.api.common.util.RedisUtil;
+import com.gam.api.config.jwt.JwtTokenManager;
+import com.gam.api.dto.social.request.SocialLogoutRequestDTO;
+import com.gam.api.dto.social.request.SocialRefreshRequestDTO;
+import com.gam.api.dto.social.response.SocialRefreshResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class SocialCommonServiceImpl implements SocialCommonService {
+    private final JwtTokenManager jwtTokenManager;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    @Transactional
+    public void logout(SocialLogoutRequestDTO socialLogoutRequestDTO) {
+        val accessRemainTime = jwtTokenManager.getAccessTokenExpirationRemainder(socialLogoutRequestDTO.accessToken());
+
+        val tokenUserId = jwtTokenManager.getUserIdFromAuthToken(socialLogoutRequestDTO.accessToken());
+
+        val userId = Long.parseLong(tokenUserId);
+
+        if (RedisUtil.checkBlackListExist(redisTemplate, userId, socialLogoutRequestDTO.accessToken())) {
+            throw new AuthException(ExceptionMessage.ALREADY_LOGOUT_TOKEN.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        if (accessRemainTime > 0) {
+            RedisUtil.saveBlackList(redisTemplate, socialLogoutRequestDTO.accessToken(), userId, accessRemainTime);
+        }
+
+        val redisRefreshKey = "refresh:user:" + userId;
+
+        val savedRefreshToken = RedisUtil.getRefreshToken(redisTemplate, userId);
+
+        if (Objects.nonNull(savedRefreshToken) && Objects.equals(socialLogoutRequestDTO.refreshToken(), savedRefreshToken.toString())) {
+            RedisUtil.deleteKey(redisTemplate, redisRefreshKey);
+        }
+    }
+
+    @Override
+    @Transactional
+    public SocialRefreshResponseDTO refresh(SocialRefreshRequestDTO socialRefreshRequestDTO) {
+        val tokenUserId = jwtTokenManager.getUserIdFromAuthToken(socialRefreshRequestDTO.accessToken());
+
+        val userId = Long.parseLong(tokenUserId);
+
+        if (!jwtTokenManager.verifyAuthToken(socialRefreshRequestDTO.refreshToken())) {
+           throw new AuthException(ExceptionMessage.EXPIRED_TOKEN.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        val redisRefreshToken = RedisUtil.getRefreshToken(redisTemplate, userId);
+
+        if (Objects.isNull(redisRefreshToken)) {
+            throw new AuthException(ExceptionMessage.INVALID_REFRESH_TOKEN.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        if (!redisRefreshToken.toString().equals(socialRefreshRequestDTO.refreshToken())) {
+            val spoiledKey = "refresh:user:" + userId;
+            RedisUtil.deleteKey(redisTemplate, spoiledKey);
+            throw new AuthException(ExceptionMessage.INVALID_REFRESH_TOKEN.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+
+        val accessToken = jwtTokenManager.createAccessToken(userId);
+        val refreshToken = jwtTokenManager.createRefreshToken(userId);
+
+        RedisUtil.saveRefreshToken(redisTemplate, refreshToken, userId);
+
+        return SocialRefreshResponseDTO.of(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/gam/api/service/social/SocialService.java
+++ b/src/main/java/com/gam/api/service/social/SocialService.java
@@ -6,6 +6,5 @@ import com.gam.api.entity.User;
 
 public interface SocialService {
     SocialLoginResponseDTO login(SocialLoginRequestDTO request);
-    void logout(Long userId);
     boolean chkProfileCompleted(User user);
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #69

## Work Description ✏️
- 로그인 시, RDBM가 아닌 redis에 refreshToken을 저장합니다 (I/O 속도 차이가 훨씬 빨라서 교체)
- 로그아웃 시, redis에서 refreshToken을 날리고, accessToken은 블랙리스트에 올려서 사용하지 못하도록 합니다
- 리프레시 시, redis의 refreshToken값과 비교하고 유효하면 교체해줍니다
- redis의 key값은 blacklist:user:4:${access_token} , refresh:user:4 입니다
- 환경변수 공유하도록 하겠습니다

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
한번 읽어봐 주세요
https://www.notion.so/with-redis-c62dd3da4600413baee5bc0cc7bfeb54?pvs=4