### PR TITLE
[WORK🛠] 신고 api개발

### DIFF
--- a/src/main/java/com/gam/api/common/message/ResponseMessage.java
+++ b/src/main/java/com/gam/api/common/message/ResponseMessage.java
@@ -58,7 +58,10 @@ public enum ResponseMessage {
 
     /** admin **/
     SUCCESS_CREATE_MAGAZINE("매거진 생성 완료"),
-    SUCCESS_EDIT_MAGAZINE("매거진 수정 완료");
+    SUCCESS_EDIT_MAGAZINE("매거진 수정 완료"),
+
+    /** report **/
+    SUCCESS_REPORT_USER("유저 신고를 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gam/api/controller/ReportController.java
+++ b/src/main/java/com/gam/api/controller/ReportController.java
@@ -1,0 +1,27 @@
+package com.gam.api.controller;
+
+import com.gam.api.common.ApiResponse;
+import com.gam.api.common.message.ResponseMessage;
+import com.gam.api.dto.report.request.ReportCreateRequestDTO;
+import com.gam.api.entity.GamUserDetails;
+import com.gam.api.service.report.ReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/report")
+public class ReportController {
+    private final ReportService reportService;
+
+    @PostMapping("")
+    public ResponseEntity<ApiResponse> createReport(@Valid @RequestBody ReportCreateRequestDTO request){
+     reportService.createReport(request);
+     return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_REPORT_USER.getMessage(), null));
+    }
+}

--- a/src/main/java/com/gam/api/controller/UserController.java
+++ b/src/main/java/com/gam/api/controller/UserController.java
@@ -141,8 +141,9 @@ public class UserController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse> searchUserAndWork(@RequestParam String keyword) {
-        val response = userService.searchUserAndWork(keyword);
+    public ResponseEntity<ApiResponse> searchUserAndWork(@AuthenticationPrincipal GamUserDetails userDetails, @RequestParam String keyword) {
+        val userId = userDetails.getId();
+        val response = userService.searchUserAndWork(userId, keyword);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_SEARCH_USE_WORKS.getMessage(),response));
     }
 }

--- a/src/main/java/com/gam/api/dto/report/request/ReportCreateRequestDTO.java
+++ b/src/main/java/com/gam/api/dto/report/request/ReportCreateRequestDTO.java
@@ -1,0 +1,15 @@
+package com.gam.api.dto.report.request;
+
+import com.gam.api.entity.Report;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+public record ReportCreateRequestDTO (
+        Long targetUserId,
+        @NotBlank
+        @NotNull
+        String content,
+        Long workId
+){
+}

--- a/src/main/java/com/gam/api/entity/Report.java
+++ b/src/main/java/com/gam/api/entity/Report.java
@@ -30,23 +30,26 @@ public class Report extends TimeStamped {
     @Column(name = "content")
     private String content;
 
-//    @OneToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "target_user_id")
-//    private User targetUser;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_user_id")
+    private User targetUser;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "work_id")
-    private Work work;
+    @Column(name = "work_Id")
+    private Long workId;
 
     @Builder
-    public Report(User targetUser, String content, Work work){
+    public Report(User targetUser, String content, Long workId){
         this.status = ReportStatus.PROCEEDING;
-//        setUser(targetUser);
+        setUser(targetUser);
         this.content = content;
-        this.work = work;
+        this.workId = workId;
     }
-//    private void setUser(User targetUser) {
-//        this.targetUser = targetUser;
-//        targetUser.setReported(this);
-//    }
+
+    private void setUser(User targetUser) {
+        if (Objects.nonNull(this.targetUser)) {
+            this.targetUser.getReported().remove(this);
+        }
+        this.targetUser = targetUser;
+        targetUser.getReported().add(this);
+    }
 }

--- a/src/main/java/com/gam/api/entity/Report.java
+++ b/src/main/java/com/gam/api/entity/Report.java
@@ -1,11 +1,14 @@
 package com.gam.api.entity;
 
 import com.gam.api.entity.superclass.TimeStamped;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+
+import java.util.Objects;
 
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -24,11 +27,26 @@ public class Report extends TimeStamped {
     @Enumerated(EnumType.STRING)
     private ReportStatus status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "content")
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_user_id")
+    private User targetUser;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "work_id")
     private Work work;
+
+    @Builder
+    public Report(User targetUser, String content, Work work){
+        this.status = ReportStatus.PROCEEDING;
+        setUser(targetUser);
+        this.content = content;
+        this.work = work;
+    }
+    private void setUser(User targetUser) {
+        this.targetUser = targetUser;
+        targetUser.setReported(this);
+    }
 }

--- a/src/main/java/com/gam/api/entity/Report.java
+++ b/src/main/java/com/gam/api/entity/Report.java
@@ -30,9 +30,9 @@ public class Report extends TimeStamped {
     @Column(name = "content")
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "target_user_id")
-    private User targetUser;
+//    @OneToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "target_user_id")
+//    private User targetUser;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "work_id")
@@ -41,12 +41,12 @@ public class Report extends TimeStamped {
     @Builder
     public Report(User targetUser, String content, Work work){
         this.status = ReportStatus.PROCEEDING;
-        setUser(targetUser);
+//        setUser(targetUser);
         this.content = content;
         this.work = work;
     }
-    private void setUser(User targetUser) {
-        this.targetUser = targetUser;
-        targetUser.setReported(this);
-    }
+//    private void setUser(User targetUser) {
+//        this.targetUser = targetUser;
+//        targetUser.setReported(this);
+//    }
 }

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -88,8 +88,8 @@ public class User extends TimeStamped {
     @OneToMany(mappedBy = "user")
     List<Work> works = new ArrayList<>();
 
-//    @OneToOne(mappedBy = "targetUser")
-//    private Report reported;
+    @OneToMany(mappedBy = "targetUser")
+    private List<Report> reported;
 
     @Type(type = "int-array")
     @Column(name = "tag",

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -88,8 +88,8 @@ public class User extends TimeStamped {
     @OneToMany(mappedBy = "user")
     List<Work> works = new ArrayList<>();
 
-    @OneToOne(mappedBy = "targetUser")
-    private Report reported;
+//    @OneToOne(mappedBy = "targetUser")
+//    private Report reported;
 
     @Type(type = "int-array")
     @Column(name = "tag",

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -88,8 +88,8 @@ public class User extends TimeStamped {
     @OneToMany(mappedBy = "user")
     List<Work> works = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
-    private List<Report> reports;
+    @OneToOne(mappedBy = "targetUser")
+    private Report reported;
 
     @Type(type = "int-array")
     @Column(name = "tag",

--- a/src/main/java/com/gam/api/entity/Work.java
+++ b/src/main/java/com/gam/api/entity/Work.java
@@ -40,9 +40,6 @@ public class Work extends TimeStamped {
     @Column(name = "view_count")
     private int viewCount;
 
-    @OneToOne(mappedBy = "work")
-    private Report report;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/gam/api/repository/ReportRepository.java
+++ b/src/main/java/com/gam/api/repository/ReportRepository.java
@@ -1,8 +1,11 @@
 package com.gam.api.repository;
 
 import com.gam.api.entity.Report;
+import com.gam.api.entity.ReportStatus;
+import com.gam.api.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReportRepository extends JpaRepository<Report, Long> {
+import java.util.Optional;
 
+public interface ReportRepository extends JpaRepository<Report, Long> {
 }

--- a/src/main/java/com/gam/api/repository/ReportRepository.java
+++ b/src/main/java/com/gam/api/repository/ReportRepository.java
@@ -1,0 +1,8 @@
+package com.gam.api.repository;
+
+import com.gam.api.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/src/main/java/com/gam/api/repository/ReportRepository.java
+++ b/src/main/java/com/gam/api/repository/ReportRepository.java
@@ -5,7 +5,9 @@ import com.gam.api.entity.ReportStatus;
 import com.gam.api.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
+    List<Report> findAllByStatus(ReportStatus status);
 }

--- a/src/main/java/com/gam/api/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.gam.api.repository;
 
 import com.gam.api.entity.Magazine;
 import com.gam.api.entity.User;
+import com.gam.api.entity.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +13,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> getUserById(Long userId);
     boolean existsByUserName(String userName);
-    List<User> findTop5ByOrderByScrapCountDesc();
+    List<User> findTop5ByUserStatusNotOrderByScrapCountDesc(UserStatus userStatus);
     List<User> findAllByIdNotOrderBySelectedFirstAtDesc(Long id);
     @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")
     List<User> findByUserName(@Param("keyword") String keyword);

--- a/src/main/java/com/gam/api/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/repository/UserRepository.java
@@ -13,8 +13,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> getUserById(Long userId);
     boolean existsByUserName(String userName);
-    List<User> findTop5ByUserStatusNotOrderByScrapCountDesc(UserStatus userStatus);
-    List<User> findAllByIdNotOrderBySelectedFirstAtDesc(Long id);
+    List<User> findTop5ByUserStatusOrderByScrapCountDesc(UserStatus userStatus);
+    List<User>findAllByIdNotAndUserStatusOrderBySelectedFirstAtDesc(Long userId, UserStatus userStatus);
     @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")
     List<User> findByUserName(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/gam/api/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/repository/UserRepository.java
@@ -17,4 +17,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User>findAllByIdNotAndUserStatusOrderBySelectedFirstAtDesc(Long userId, UserStatus userStatus);
     @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")
     List<User> findByUserName(@Param("keyword") String keyword);
+    @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% and u.userStatus!='REPORTED' and u.id!=:userId ORDER BY u.createdAt DESC")
+    List<User> findByKeyWord(@Param("userId")Long userId, @Param("keyword") String keyword);
+
+    @Query("SELECT u FROM User u JOIN FETCH u.works WHERE u.userStatus = :userStatus")
+    List<User> findAllByUserStatusWithWorks( @Param("userStatus") UserStatus userStatus);
 }

--- a/src/main/java/com/gam/api/repository/UserScrapRepository.java
+++ b/src/main/java/com/gam/api/repository/UserScrapRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
     UserScrap findByUser_idAndTargetId(Long userId, Long targetId);
-    List<UserScrap> getAllByUser_idAndStatus(Long userId, boolean status);
+    List<UserScrap> getAllByUser_idAndStatusOrderByCreatedAtDesc(Long userId, boolean status);
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -15,4 +15,5 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     List<Work> findByUserId(Long userId);
     @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE %:keyword% ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
+    Work findByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/gam/api/service/report/ReportService.java
+++ b/src/main/java/com/gam/api/service/report/ReportService.java
@@ -1,0 +1,7 @@
+package com.gam.api.service.report;
+
+import com.gam.api.dto.report.request.ReportCreateRequestDTO;
+
+public interface ReportService {
+    void createReport(ReportCreateRequestDTO request);
+}

--- a/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
+++ b/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
@@ -1,0 +1,49 @@
+package com.gam.api.service.report;
+
+import com.gam.api.common.message.ExceptionMessage;
+import com.gam.api.dto.report.request.ReportCreateRequestDTO;
+import com.gam.api.entity.Report;
+import com.gam.api.entity.User;
+import com.gam.api.entity.Work;
+import com.gam.api.repository.ReportRepository;
+import com.gam.api.repository.UserRepository;
+import com.gam.api.repository.WorkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService{
+    private final UserRepository userRepository;
+    private final WorkRepository workRepository;
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    @Override
+    public void createReport(ReportCreateRequestDTO request) {
+        val targetUser = findUser(request.targetUserId());
+        val reportedWork = findWork(request.workId());
+
+        val report = Report.builder()
+                                    .targetUser(targetUser)
+                                    .content(request.content())
+                                    .work(reportedWork)
+                                    .build();
+
+        reportRepository.save(report);
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
+    }
+
+    private Work findWork(Long workId) {
+        return workRepository.findById(workId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
+    }
+}

--- a/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
+++ b/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
@@ -21,11 +21,13 @@ import javax.persistence.EntityNotFoundException;
 public class ReportServiceImpl implements ReportService{
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
+    private final WorkRepository workRepository;
 
     @Transactional
     @Override
     public void createReport(ReportCreateRequestDTO request) {
         val targetUser = findUser(request.targetUserId());
+        findWork(request.workId());
 
         val report = Report.builder()
                                     .targetUser(targetUser)
@@ -39,5 +41,10 @@ public class ReportServiceImpl implements ReportService{
     private User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
+    }
+
+    private Work findWork(Long workId) {
+        return workRepository.findById(workId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
     }
 }

--- a/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
+++ b/src/main/java/com/gam/api/service/report/ReportServiceImpl.java
@@ -4,6 +4,7 @@ import com.gam.api.common.message.ExceptionMessage;
 import com.gam.api.dto.report.request.ReportCreateRequestDTO;
 import com.gam.api.entity.Report;
 import com.gam.api.entity.User;
+import com.gam.api.entity.UserStatus;
 import com.gam.api.entity.Work;
 import com.gam.api.repository.ReportRepository;
 import com.gam.api.repository.UserRepository;
@@ -19,19 +20,17 @@ import javax.persistence.EntityNotFoundException;
 @RequiredArgsConstructor
 public class ReportServiceImpl implements ReportService{
     private final UserRepository userRepository;
-    private final WorkRepository workRepository;
     private final ReportRepository reportRepository;
 
     @Transactional
     @Override
     public void createReport(ReportCreateRequestDTO request) {
         val targetUser = findUser(request.targetUserId());
-        val reportedWork = findWork(request.workId());
 
         val report = Report.builder()
                                     .targetUser(targetUser)
                                     .content(request.content())
-                                    .work(reportedWork)
+                                    .workId(request.workId())
                                     .build();
 
         reportRepository.save(report);
@@ -40,10 +39,5 @@ public class ReportServiceImpl implements ReportService{
     private User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
-    }
-
-    private Work findWork(Long workId) {
-        return workRepository.findById(workId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
     }
 }

--- a/src/main/java/com/gam/api/service/user/UserService.java
+++ b/src/main/java/com/gam/api/service/user/UserService.java
@@ -26,5 +26,5 @@ public interface UserService {
     void updateInstagramLink(Long userId, UserUpdateLinkRequestDTO request);
     void updateBehanceLink(Long userId, UserUpdateLinkRequestDTO request);
     void updateNotionLink(Long userId, UserUpdateLinkRequestDTO request);
-    List<SearchUserWorkDTO> searchUserAndWork(String keyword);
+    List<SearchUserWorkDTO> searchUserAndWork(Long userId, String keyword);
     }

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -228,13 +228,17 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<UserDiscoveryResponseDTO> getDiscoveryUsers(Long userId) {
+        System.out.println("here");
         val users = userRepository.findAllByIdNotOrderBySelectedFirstAtDesc(userId);
+//        val users = userRepository.findAllByIdNotAndUserStatusNotOrderBySelectedFirstAtDesc(userId, UserStatus.REPORTED);
 
         return users.stream().map((user) -> {
             val targetUserId = user.getId();
+            System.out.println(targetUserId);
             val firstWorkId = user.getFirstWorkId();
+            System.out.println(firstWorkId==null);
             val firstWork = findWork(firstWorkId);
-
+            System.out.println(firstWorkId==null);
             val userScrap = userScrapRepository.findByUser_idAndTargetId(userId, targetUserId);
             if (Objects.isNull(userScrap)) {
                 return UserDiscoveryResponseDTO.of(user, false, firstWork);

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -94,7 +94,7 @@ public class UserServiceImpl implements UserService {
 
         if (!userList.isEmpty()) {
             userList.stream()
-                    .map((user) -> workSet.addAll(workRepository.findByUserId(user.getId())));
+                    .map((user) -> workSet.addAll(user.getWorks()));
         }
 
         // 키워드에 맞는 work모두 갖고와서 hashSet에 추가 (중복 제거를 위함)
@@ -179,14 +179,14 @@ public class UserServiceImpl implements UserService {
         return scraps.stream()
                 .filter(scrap -> {
                     val targetId = scrap.getTargetId();
-                    User targetUser = userRepository.findById(targetId)
+                    val targetUser = userRepository.findById(targetId)
                             .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
                     return !checkReportedUser(targetUser); // 신고 처리된 유저가 아닌 경우
                 })
                 .map(scrap -> {
                     val scrapId = scrap.getId();
                     val targetId = scrap.getTargetId();
-                    User targetUser = userRepository.findById(targetId)
+                    val targetUser = userRepository.findById(targetId)
                             .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
                     return UserScrapsResponseDTO.of(scrapId, targetUser);
                 })

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -191,7 +191,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<UserResponseDTO> getPopularDesigners(Long userId) {
-        val users = userRepository.findTop5ByOrderByScrapCountDesc();
+        val users = userRepository.findTop5ByUserStatusNotOrderByScrapCountDesc(UserStatus.REPORTED);
         return users.stream().map((user) -> {
             val userScrap = userScrapRepository.findByUser_idAndTargetId(userId, user.getId());
             if (Objects.nonNull(userScrap)){


### PR DESCRIPTION
## Related Issue 🚀
- #100 

## Work Description ✏️
- 신고 api 개발을 완료했습니다.
- 신고 api도입에 따라 수정된 부분은, 노션의 이모지를 '빨간하트'로 바꿔놨습니다.

- 노션 페이지 바로가기 https://www.notion.so/3f453d3004db4588a8907d37c1bc3984?v=c6caa0e11eb54b5985e60fee6c2c0e5d&p=f4e09fd8244b40e789900adad6626d47&pm=s

### 총 고친 api는 
- 메인 홈 - 감잡은 디자이너` /api/v1/user/popular`
- 발견 - 유저  `/api/v1/user`
- 발견 - 유저 스크랩 뷰  `/api/v1/user/scraps`
- **둘러보기 - 검색 `/api/v1/user/search?keyword={keyword}`**
- 신고 생성 `/api/v1/report` 입니다.


# PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->

## Fix 
-  `/api/v1/user` API에서 user의 대표 작업물이 설정이 안돼있을 경우( 혹시모를 오류 대비 ) 갖고 있는 work중에서 가장 최근에 올린거로 repsponse를 보냅니다. 

## Feature 개발 
- 신고 api를 작업하는 동안, report의 연관 관계를 줄이기 위해
   Report - Work 은 연관 관계를 두지 않았습니다. 


- 다른 api들은 대부분 쿼리를 통해서 해결했는데, 
  둘러보기 - 검색 `/api/v1/user/search?keyword={keyword}`은 로직이 좀 복잡해서, 코드를 잘 봐주시면 감사할 것 같아요!

### **- 둘러보기 -검색 logic설명** 
- set자료구조 사용 ( work의 중복 제거를 위함 ) 
                    ->   가희- [가희work] 일 경우
                        '가희' 유저이름에 해당하는 작업물들 + '가희' 작업물 검색
                        => [가희work, 가희work] 로 검색 결과가 중복됨 


Logic 1 .  키워드에 해당하는 유저들을 갖고온다. ('나'와, 키워드에 해당하지만 신고된 유저들 제외 ) 
Logic 2. 키워드에 해당하는 work들을 갖고와서, set에 추가
Logic 3. 신고된 유저들의 작업물들을 갖고옴
Logic 4. 모아놓은 workSet에서 제외 
Logic 5. Response Return

-> 3,4번의 이유 
신고된 유저가 keyword에 해당하는 작업물을 갖을 경우 제외하기 위해서
ex) 
전제상황 
DB ) 유저명 - workList
전제상황 1 ) 용택- [가희title, 가희title2]
전제상황 2 ) 용택 - 신고당함 

전제상황 3 )keyworkd = '가희'검색

결과
신고 api 적용 전 ) 용택- 가희title, 가희title2
신고 api 적용 후 ) null

설명 
가희title, 가희title2이 Logic 2(키워드에 해당하는 work들을 갖고와서, set에 추가) 에 의해서 검색이 되지만, 
Logic 3, Logic 4 (신고된 유저의 작품은 보이지 않는다. )에 의하여 제외됨


