### PR TITLE
fix: 내 포토폴리오 보기 로직 수정

### DIFF
--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -255,18 +255,6 @@ public class UserServiceImpl implements UserService {
     }
 
 
-    private List<Work> getMineFolio(Long userId) { //TODO - 메소드 네이밍..
-        val works = workRepository.findByUserIdAndIsFirstOrderByCreatedAtDesc(userId, false);
-
-        val representiveWork = workRepository.getWorkByUserIdAndIsFirst(userId, true);
-        if (representiveWork.isPresent()){
-            works.add(0, representiveWork.get());
-            return works;
-        }
-        return works;
-    }
-
-
     @Transactional
     @Override
     public WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId) {
@@ -308,6 +296,17 @@ public class UserServiceImpl implements UserService {
             }
             return UserDiscoveryResponseDTO.of(user, userScrap.isStatus(), firstWork);
         }).collect(Collectors.toList());
+    }
+
+    private List<Work> getMineFolio(Long userId) { //TODO - 메소드 네이밍..
+        val works = workRepository.findByUserIdAndIsFirstOrderByCreatedAtDesc(userId, false);
+
+        val representiveWork = workRepository.getWorkByUserIdAndIsFirst(userId, true);
+        if (representiveWork.isPresent()){
+            works.add(0, representiveWork.get());
+            return works;
+        }
+        return works;
     }
 
     private List<Work> getUserPortfolio(Long userId) {

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -250,8 +250,20 @@ public class UserServiceImpl implements UserService {
     @Override
     public WorkPortfolioListResponseDTO getMyPortfolio(Long userId) {
         val user = findUser(userId);
-        val works = getUserPortfolio(userId);
+        val works = getMineFolio(userId); //TODO - 메소드 네이밍..
         return WorkPortfolioListResponseDTO.of(user, works);
+    }
+
+
+    private List<Work> getMineFolio(Long userId) { //TODO - 메소드 네이밍..
+        val works = workRepository.findByUserIdAndIsFirstOrderByCreatedAtDesc(userId, false);
+
+        val representiveWork = workRepository.getWorkByUserIdAndIsFirst(userId, true);
+        if (representiveWork.isPresent()){
+            works.add(0, representiveWork.get());
+            return works;
+        }
+        return works;
     }
 
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #109 

## Work Description ✏️
- 기존의 'getUserPortfolio'를 '포토폴리오 보기'로 한번에 사용하지 않고,
'내 포토폴리오 보기' 메서드를 생성하여(getMineFolio) 클라이언트에게 return합니다.

