### PR TITLE
[FIX] 매거진 조회 limit 로직 설정  

### DIFF
--- a/src/main/java/com/gam/api/controller/MagazineController.java
+++ b/src/main/java/com/gam/api/controller/MagazineController.java
@@ -24,8 +24,8 @@ public class MagazineController {
     }
 
     @GetMapping("/detail")
-    public ResponseEntity<ApiResponse> getMagazineDetail(@RequestParam Long magazineId) {
-        val response = magazineService.getMagazineDetail(magazineId);
+    public ResponseEntity<ApiResponse> getMagazineDetail(@RequestParam Long magazineId, @AuthenticationPrincipal GamUserDetails userDetails) {
+        val response = magazineService.getMagazineDetail(magazineId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_GET_MAGAZINE_DETAIL.getMessage(), response));
     }
 

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -80,6 +80,9 @@ public class User extends TimeStamped {
     @Column(name = "device_token")
     private String deviceToken;
 
+    @Column(name = "magazine_view_count")
+    private int magazineViewCount;
+
     @OneToMany(mappedBy = "user")
     private List<Block> blocks;
 
@@ -119,6 +122,7 @@ public class User extends TimeStamped {
         this.userStatus = userStatus;
         this.scrapCount = 0;
         this.viewCount = 0;
+        this.magazineViewCount = 0;
     }
 
     public void updateUserStatus(UserStatus userStatus) {
@@ -129,9 +133,17 @@ public class User extends TimeStamped {
         this.deviceToken = deviceToken;
     }
 
-    public void scrapCountUp(){ this.scrapCount += 1; }
+    public void scrapCountUp() {
+        this.scrapCount += 1;
+    }
 
-    public void scrapCountDown(){ this.scrapCount -= 1; }
+    public void magazineViewCountUp() {
+        this.magazineViewCount += 1;
+    }
+
+    public void scrapCountDown() {
+        this.scrapCount -= 1;
+    }
 
     public void onboardUser(String userName, String info, int[] tags) {
         this.userName = userName;

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -136,12 +136,12 @@ public class User extends TimeStamped {
         this.scrapCount += 1;
     }
 
-    public void magazineViewCountUp() {
-        this.magazineViewCount += 1;
-    }
-
     public void scrapCountDown() {
         this.scrapCount -= 1;
+    }
+
+    public void magazineViewCountUp() {
+        this.magazineViewCount += 1;
     }
 
     public void onboardUser(String userName, String info, int[] tags) {

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -13,7 +13,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/main/java/com/gam/api/service/magazine/MagazineService.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface MagazineService {
     MagazineResponseDTO getMagazines(Long userId);
-    MagazineDetailResponseDTO getMagazineDetail(Long magazineID);
+    MagazineDetailResponseDTO getMagazineDetail(Long magazineID, Long userId);
     MagazineScrapsResponseDTO getMagazineScraps(Long userId);
     MagazineResponseDTO getPopularMagazines(Long userId);
     MagazineScrapResponseDTO scrapMagazine(Long userId, MagazineScrapRequestDTO magazineScrapRequestDTO);

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -47,11 +47,14 @@ public class MagazineServiceImpl implements MagazineService {
         val magazine = getMagazine(magazineId);
         val user = findUser(userId);
 
-        if (user.getMagazineViewCount() >= 2 && user.getWorks().size() == 0) {
+        if (user.getMagazineViewCount() == 2 && user.getWorks().size() == 0) {
             user.updateUserStatus(UserStatus.NOT_PERMITTED);
         }
 
-        user.magazineViewCountUp();
+        if (user.getMagazineViewCount() < 3) {
+            user.magazineViewCountUp();
+        }
+
         magazine.setViewCount(magazine.getViewCount() + 1);
         return MagazineDetailResponseDTO.of(magazine);
     }

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -7,6 +7,7 @@ import com.gam.api.dto.magazine.response.*;
 import com.gam.api.entity.Magazine;
 import com.gam.api.entity.MagazineScrap;
 import com.gam.api.entity.User;
+import com.gam.api.entity.UserStatus;
 import com.gam.api.entity.superclass.TimeStamped;
 import com.gam.api.repository.MagazineRepository;
 import com.gam.api.repository.MagazineScrapRepository;
@@ -42,8 +43,15 @@ public class MagazineServiceImpl implements MagazineService {
 
     @Transactional
     @Override
-    public MagazineDetailResponseDTO getMagazineDetail(Long magazineId) {
+    public MagazineDetailResponseDTO getMagazineDetail(Long magazineId, Long userId) {
         val magazine = getMagazine(magazineId);
+        val user = findUser(userId);
+
+        if (user.getMagazineViewCount() == 2) {
+            user.updateUserStatus(UserStatus.NOT_PERMITTED);
+        }
+
+        user.magazineViewCountUp();
         magazine.setViewCount(magazine.getViewCount() + 1);
         return MagazineDetailResponseDTO.of(magazine);
     }

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -47,7 +47,7 @@ public class MagazineServiceImpl implements MagazineService {
         val magazine = getMagazine(magazineId);
         val user = findUser(userId);
 
-        if (user.getMagazineViewCount() == 2) {
+        if (user.getMagazineViewCount() >= 2 && user.getWorks().size() == 0) {
             user.updateUserStatus(UserStatus.NOT_PERMITTED);
         }
 

--- a/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
+++ b/src/main/java/com/gam/api/service/magazine/MagazineServiceImpl.java
@@ -46,12 +46,14 @@ public class MagazineServiceImpl implements MagazineService {
     public MagazineDetailResponseDTO getMagazineDetail(Long magazineId, Long userId) {
         val magazine = getMagazine(magazineId);
         val user = findUser(userId);
+        val magazineCount = user.getMagazineViewCount();
+        val isWorkEmpty = user.getWorks().size() == 0;
 
-        if (user.getMagazineViewCount() == 2 && user.getWorks().size() == 0) {
+        if (magazineCount == 2 && isWorkEmpty) {
             user.updateUserStatus(UserStatus.NOT_PERMITTED);
         }
 
-        if (user.getMagazineViewCount() < 3) {
+        if (magazineCount < 3 && isWorkEmpty) {
             user.magazineViewCountUp();
         }
 

--- a/src/main/java/com/gam/api/service/social/SocialCommonServiceImpl.java
+++ b/src/main/java/com/gam/api/service/social/SocialCommonServiceImpl.java
@@ -59,7 +59,7 @@ public class SocialCommonServiceImpl implements SocialCommonService {
     ) {
         val user = userRepository.save(User.builder()
                 .role(Role.USER)
-                .userStatus(UserStatus.NOT_PERMITTED)
+                .userStatus(UserStatus.PERMITTED)
                 .build());
 
         val userId = user.getId();


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #122

## Work Description ✏️
-  첫 가입 시 PERMITTED 로 두기
-  매거진 호출 마다 count++ 해주기
    -  호출 직전 최하단에 count가 3이 되는 쿼리 날릴 시 NOT_PERMITTED로 변경하는 쿼리도 날리기
-  게시글 올릴 때, 게시글 개수 확인하여서 0개일 때 호출하면 PERMITTED로 변경 
-  게시글 삭제시 하나도 없게 된다면 NOT_PERMITTED로 변경  

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
