### PR TITLE
[FIX] Work 생성, 삭제 로직 수정 

### DIFF
--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -38,6 +38,7 @@ public enum ExceptionMessage {
     NOT_FOUND_FIRST_WORK("대표 작업을 찾을 수 없습니다."),
     NOT_WORK_OWNER("작업물의 주인이 아닙니다."),
     WORK_NO_THUMBNAIL("작업물의 썸네일이 없습니다."),
+    ALREADY_NOT_ACTIVE_WORK("이미 비활성화 된 작업물 입니다."),
 
     /** Magazine **/
     NOT_FOUND_MAGAZINE("해당하는 매거진을 찾을 수 없습니다."),

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -3,6 +3,7 @@ package com.gam.api.entity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.gam.api.entity.superclass.TimeStamped;
 import io.hypersistence.utils.hibernate.type.array.IntArrayType;
+import java.util.stream.Collectors;
 import lombok.*;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.Where;
@@ -119,6 +120,13 @@ public class User extends TimeStamped {
         this.userStatus = userStatus;
         this.scrapCount = 0;
         this.viewCount = 0;
+    }
+
+    public List<Work> getActiveWorks() {
+        List<Work> activeWorks = this.getWorks()
+                .stream()
+                .filter(Work::isActive)  // isActive가 true인 Work 객체만 필터링
+                .collect(Collectors.toList());
     }
 
     public void updateUserStatus(UserStatus userStatus) {

--- a/src/main/java/com/gam/api/entity/User.java
+++ b/src/main/java/com/gam/api/entity/User.java
@@ -123,9 +123,9 @@ public class User extends TimeStamped {
     }
 
     public List<Work> getActiveWorks() {
-        List<Work> activeWorks = this.getWorks()
+        return this.getWorks()
                 .stream()
-                .filter(Work::isActive)  // isActive가 true인 Work 객체만 필터링
+                .filter(Work::isActive)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/gam/api/entity/Work.java
+++ b/src/main/java/com/gam/api/entity/Work.java
@@ -40,6 +40,9 @@ public class Work extends TimeStamped {
     @Column(name = "is_first")
     private boolean isFirst;
 
+    @Column(name = "is_active")
+    private boolean isAcitve;
+
 
     @Builder
     public Work(User user, String title, String detail, String photoUrl) {
@@ -48,6 +51,7 @@ public class Work extends TimeStamped {
         this.detail = detail;
         this.photoUrl = photoUrl;
         this.viewCount = 0;
+        this.isAcitve = true;
     }
 
     public boolean isOwner(Long userId) {

--- a/src/main/java/com/gam/api/entity/Work.java
+++ b/src/main/java/com/gam/api/entity/Work.java
@@ -41,7 +41,7 @@ public class Work extends TimeStamped {
     private boolean isFirst;
 
     @Column(name = "is_active")
-    private boolean isAcitve;
+    private boolean isActive;
 
 
     @Builder
@@ -52,7 +52,7 @@ public class Work extends TimeStamped {
         this.photoUrl = photoUrl;
         this.viewCount = 0;
         this.isFirst = false;
-        this.isAcitve = true;
+        this.isActive = true;
     }
 
     public boolean isOwner(Long userId) {

--- a/src/main/java/com/gam/api/entity/Work.java
+++ b/src/main/java/com/gam/api/entity/Work.java
@@ -51,6 +51,7 @@ public class Work extends TimeStamped {
         this.detail = detail;
         this.photoUrl = photoUrl;
         this.viewCount = 0;
+        this.isFirst = false;
         this.isAcitve = true;
     }
 

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -15,5 +15,5 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     List<Work> findAllByUserId(Long userId);
     @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
-    Optional<Work> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<Work> findFirstByUserIdAndIsActiveOrderByCreatedAtDesc(Long userId, boolean isActive);
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -15,5 +15,5 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     List<Work> findAllByUserId(Long userId);
     @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
-    Work findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<Work> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/gam/api/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/repository/WorkRepository.java
@@ -15,5 +15,5 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     List<Work> findAllByUserId(Long userId);
     @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
-    Work findByUserIdOrderByCreatedAtDesc(Long userId);
+    Work findFirstByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -100,7 +100,7 @@ public class UserServiceImpl implements UserService {
         // 신고 된 유저 작업물 제외, fetch-join 이용
         val reportedWorksSet = userRepository.findAllByUserStatusWithWorks(UserStatus.REPORTED)
                 .stream()
-                .flatMap(user -> user.getWorks().stream())
+                .flatMap(user -> user.getActiveWorks().stream())
                 .collect(Collectors.toSet());
         workSet.removeAll(reportedWorksSet);
 
@@ -108,7 +108,7 @@ public class UserServiceImpl implements UserService {
         val me = findUser(myId);
         List<User> blockUsers = getBlockUsers(me);
         val blockedWorksSet = blockUsers.stream() //TODO[성능] - 성능저하 가능성 있음
-                                        .flatMap(user -> user.getWorks().stream())
+                                        .flatMap(user -> user.getActiveWorks().stream())
                                         .collect(Collectors.toSet());
         workSet.removeAll(blockedWorksSet);
 
@@ -279,7 +279,7 @@ public class UserServiceImpl implements UserService {
             val firstWorkId = user.getFirstWorkId();
             Work firstWork;
 
-            if (firstWorkId == null && !user.getWorks().isEmpty()) { // firstWork가 설정이 제대로 안된 경우
+            if (firstWorkId == null && !user.getActiveWorks().isEmpty()) { // firstWork가 설정이 제대로 안된 경우
                 firstWork = workRepository.findFirstByUserIdAndIsActiveOrderByCreatedAtDesc(userId, true)
                                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
             } else {

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -108,8 +108,8 @@ public class UserServiceImpl implements UserService {
         val me = findUser(myId);
         List<User> blockUsers = getBlockUsers(me);
         val blockedWorksSet = blockUsers.stream() //TODO[성능] - 성능저하 가능성 있음
-                                        .flatMap(user -> user.getActiveWorks().stream())
-                                        .collect(Collectors.toSet());
+                .flatMap(user -> user.getActiveWorks().stream())
+                .collect(Collectors.toSet());
         workSet.removeAll(blockedWorksSet);
 
         val workList = new ArrayList<>(workSet);

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -280,7 +280,8 @@ public class UserServiceImpl implements UserService {
             Work firstWork;
 
             if (firstWorkId == null && !user.getWorks().isEmpty()) { // firstWork가 설정이 제대로 안된 경우
-                firstWork = workRepository.findByUserIdOrderByCreatedAtDesc(targetUserId);
+                firstWork = workRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+                                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
             } else {
                 firstWork = findWork(firstWorkId);
             }

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -280,7 +280,7 @@ public class UserServiceImpl implements UserService {
             Work firstWork;
 
             if (firstWorkId == null && !user.getWorks().isEmpty()) { // firstWork가 설정이 제대로 안된 경우
-                firstWork = workRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+                firstWork = workRepository.findFirstByUserIdAndIsActiveOrderByCreatedAtDesc(userId, true)
                                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
             } else {
                 firstWork = findWork(firstWorkId);

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -76,8 +76,9 @@ public class WorkServiceImpl implements WorkService {
         }
 
         val wasFirst = work.isFirst();
-        val workCount = user.getWorks().size();
-        workRepository.deleteById(workId);
+        val workCount = user.getActiveWorks().size();
+        work.setActive(false);
+        work.setIsFirst(false);
 
         if (workCount == 1) { // 작업물이 한개 였을 때
             user.setSelectedFirstAt(null);
@@ -86,8 +87,8 @@ public class WorkServiceImpl implements WorkService {
             return WorkResponseDTO.of(workId);
         }
 
-        if (wasFirst) {
-            val recentWork = workRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+        if (wasFirst) { // 작업물이 두개 이상이었을 때
+            val recentWork = workRepository.findFirstByUserIdAndIsActiveOrderByCreatedAtDesc(userId, true)
                                                  .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_WORK.getMessage()));
             setFirstWork(user, recentWork);
         }

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -43,6 +43,10 @@ public class WorkServiceImpl implements WorkService {
             throw new WorkException(ExceptionMessage.WORK_COUNT_EXCEED.getMessage(), HttpStatus.BAD_REQUEST);
         }
 
+        if (user.getUserStatus().equals(UserStatus.NOT_PERMITTED)) {
+            user.updateUserStatus(UserStatus.PERMITTED);
+        }
+
         if (request.image().isEmpty()) {
             throw new WorkException(ExceptionMessage.WORK_NO_THUMBNAIL.getMessage(), HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/service/work/WorkServiceImpl.java
@@ -38,7 +38,7 @@ public class WorkServiceImpl implements WorkService {
     public WorkResponseDTO createWork(Long userId, WorkCreateRequestDTO request) {
         val user = findUser(userId);
 
-        val userWorkCount = user.getWorks().size();
+        val userWorkCount = user.getActiveWorks().size();
         if (userWorkCount >= MAX_WORK_COUNT) {
             throw new WorkException(ExceptionMessage.WORK_COUNT_EXCEED.getMessage(), HttpStatus.BAD_REQUEST);
         }


### PR DESCRIPTION
## Related Issue 🚀
- #124 

## Work Description ✏️
- 생성 로직 수정
  1. 첫 작업물일 경우, 대표 게시글로 설정
  2. 매직넘버 상수화 ( 최대 업로드 할 수 있는 작업물 개수) 
  3. 생성할 수 있는 최대 작업물 수 3개로 기획 반영 (기존 코드는 생성할 수 있는 최대 작업물이 4개였음)
  4. 대표 작업물로 설정하는 메소드 extract

- 삭제 로직 수정
1. 유저 작업물 개수가 1개이고, 삭제하려는 작업물이 대표 작업물 일 경우 (작업물 개수가1개면 무조건 대표게시글이긴 함) 
-> user엔티티의 selectedFirstAt , workThumbNail, firstWorkId null로 설정
2. 유저 작업물의 개수가 2개이상이고, 삭제하려는 작업물이 대표 작업물 일 경우
-> 가장 최신 게시글을 대표 작업물로 변경
3. 유저 작업물 개수가 2개이상이고, 삭제하려는 작업물이 그냥 작업물일 때
-> 그냥 삭제

- s3에 올려진 사진 삭제 로직 없앰 


## PR Point 📸
- work를 삭제 하지 않는 기획사항에 의하여 기존의 user.getWorks()를 대신하여 아래와 같은 메소드를 선언했습니다.
<img width="419" alt="스크린샷 2024-01-19 오후 4 58 37" src="https://github.com/Gam-develop/gam-server/assets/77230391/fcb526fa-43d1-47a4-a677-cae43b0f4b8c">

- 또한 기존의 getWorks()를 사용하던 함수들에도 변경을 했습니다. 
