### PR TITLE
fix: 관리자 메거진 detail count+1 이슈 해결 #136

### DIFF
--- a/src/main/java/com/gam/api/controller/AdminController.java
+++ b/src/main/java/com/gam/api/controller/AdminController.java
@@ -3,11 +3,13 @@ package com.gam.api.controller;
 import com.gam.api.common.ApiResponse;
 import com.gam.api.common.message.ResponseMessage;
 import com.gam.api.dto.admin.magazine.request.MagazineRequestDTO;
+import com.gam.api.entity.GamUserDetails;
 import com.gam.api.service.admin.AdminService;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -37,6 +39,14 @@ public class AdminController {
         adminService.createMagazine(request);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_CREATE_MAGAZINE.getMessage()));
     }
+
+    @ApiOperation(value = "관리자 매거진 - 세부")
+    @GetMapping("/magazine/detail")
+    public ResponseEntity<ApiResponse> getMagazineDetail(@RequestParam Long magazineId, @AuthenticationPrincipal GamUserDetails userDetails) {
+        val response = adminService.getMagazineDetail(magazineId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_GET_MAGAZINE_DETAIL.getMessage(), response));
+    }
+
 
     @ApiOperation(value = "매거진 - 수정")
     @PatchMapping("/magazine/{magazineId}")

--- a/src/main/java/com/gam/api/dto/admin/magazine/response/MagazineDetailResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/admin/magazine/response/MagazineDetailResponseDTO.java
@@ -1,0 +1,46 @@
+package com.gam.api.dto.admin.magazine.response;
+
+import com.gam.api.entity.Magazine;
+import com.gam.api.entity.Question;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record MagazineDetailResponseDTO(
+        Long magazineId,
+        List<String> magazinePhotos,
+        String magazineIntro,
+        List<MagazineDetailResponseVO> questions
+) {
+    public static MagazineDetailResponseDTO of(
+            Magazine magazine
+    ) {
+        return MagazineDetailResponseDTO.builder()
+                .magazineId(magazine.getId())
+                .magazinePhotos(List.of(magazine.getMagazine_photos()))
+                .magazineIntro(magazine.getIntroduction())
+                .questions(magazine.getQuestions().stream().map(MagazineDetailResponseVO::of).toList())
+                .build();
+    }
+}
+
+@Builder
+record MagazineDetailResponseVO(
+        Long questionId,
+        int questionOrder,
+        String question,
+        String answer,
+        String answerImage,
+        String imageCaption
+) {
+    public static MagazineDetailResponseVO of(Question question) {
+        return MagazineDetailResponseVO.builder()
+                .questionId(question.getId())
+                .questionOrder(question.getQuestionOrder())
+                .question(question.getQuestion())
+                .answer(question.getAnswer())
+                .answerImage(question.getAnswerImage())
+                .imageCaption(question.getImageCaption())
+                .build();
+    }
+}

--- a/src/main/java/com/gam/api/service/admin/AdminService.java
+++ b/src/main/java/com/gam/api/service/admin/AdminService.java
@@ -1,6 +1,7 @@
 package com.gam.api.service.admin;
 
 import com.gam.api.dto.admin.magazine.request.MagazineRequestDTO;
+import com.gam.api.dto.admin.magazine.response.MagazineDetailResponseDTO;
 import com.gam.api.dto.admin.magazine.response.MagazineListResponseDTO;
 
 import java.util.List;
@@ -11,4 +12,5 @@ public interface AdminService {
     void createMagazine(MagazineRequestDTO request);
     void editMagazine(Long magazineId, MagazineRequestDTO request);
     void deleteUserAccount(Long userId);
+    MagazineDetailResponseDTO getMagazineDetail(Long magazineID, Long userId);
 }

--- a/src/main/java/com/gam/api/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/gam/api/service/admin/AdminServiceImpl.java
@@ -5,8 +5,10 @@ import com.gam.api.common.message.ExceptionMessage;
 import com.gam.api.dto.admin.magazine.request.MagazineRequestDTO;
 import com.gam.api.dto.admin.magazine.response.MagazineListResponseDTO;
 
+import com.gam.api.dto.admin.magazine.response.MagazineDetailResponseDTO;
 import com.gam.api.entity.Magazine;
 import com.gam.api.entity.Question;;
+import com.gam.api.entity.UserStatus;
 import com.gam.api.entity.Work;
 import com.gam.api.repository.MagazineRepository;
 import com.gam.api.repository.QuestionRepository;
@@ -171,5 +173,13 @@ public class AdminServiceImpl implements AdminService {
         }
 
         userRepository.deleteById(userId);
+    }
+
+    @Override
+    public MagazineDetailResponseDTO getMagazineDetail(Long magazineId, Long userId) {
+        val magazine = magazineRepository.findById(magazineId)
+                .orElseThrow(()-> new EntityNotFoundException());
+
+        return MagazineDetailResponseDTO.of(magazine);
     }
 }

--- a/src/main/java/com/gam/api/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/gam/api/service/admin/AdminServiceImpl.java
@@ -41,8 +41,7 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public void deleteMagazine(Long magazineId) {
-        magazineRepository.findById(magazineId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MAGAZINE.getMessage()));
+        findMagazine(magazineId);
 
         magazineRepository.deleteById(magazineId);
     }
@@ -177,9 +176,13 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     public MagazineDetailResponseDTO getMagazineDetail(Long magazineId, Long userId) {
-        val magazine = magazineRepository.findById(magazineId)
-                .orElseThrow(()-> new EntityNotFoundException());
+        val magazine = findMagazine(magazineId);
 
         return MagazineDetailResponseDTO.of(magazine);
+    }
+
+    private Magazine findMagazine(Long magazineId) {
+        return magazineRepository.findById(magazineId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MAGAZINE.getMessage()));
     }
 }


### PR DESCRIPTION
## Related Issue 🚀
- #136

## Work Description ✏️
- 관리자 페이지에서 매거진 detail을 호출하면 count+1이 되어, 수정이 안되도 정렬이 바뀌는 문제가 생겼습니다.
- 따라서 api를 새로 만들어서 이를 해결 했습니당 
+ 약간의 메소드 추출 

