### PR TITLE
[CHORE] userTag 리턴값 "" to Null, Token 에러 catch

### DIFF
--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ExceptionMessage {
     /** auth **/
     SECURITY_FILTER_EXCPETION("시큐리티 예외"),
+    TOKEN_USER_EXCEPTION("토큰 에러 - 토큰에 해당하는 유저를 찾을 수 없습니다."),
     WITHDRAWAL_USER("탈퇴한 사용자입니다."),
     EMPTY_TOKEN("빈 토큰입니다."),
     INVALID_TOKEN("유효하지 않은 토큰입니다."),

--- a/src/main/java/com/gam/api/config/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/gam/api/config/jwt/JwtExceptionFilter.java
@@ -2,6 +2,7 @@ package com.gam.api.config.jwt;
 
 import com.gam.api.common.ApiResponse;
 import com.gam.api.common.exception.AuthException;
+import javax.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -26,11 +27,15 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         try {
             filterChain.doFilter(httpServletRequest, httpServletResponse);
-        } catch(AuthException e) {
+        } catch(AuthException | EntityNotFoundException e) {
             val objectMapper = new ObjectMapper();
-            val jsonResponse = objectMapper.writeValueAsString(ApiResponse.fail(e.getMessage()));
+            String jsonResponse = objectMapper.writeValueAsString(ApiResponse.fail(e.getMessage()));
 
-            httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+            if(e instanceof AuthException) {
+                httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+            } else if(e instanceof EntityNotFoundException) {
+                httpServletResponse.setStatus(HttpStatus.NOT_FOUND.value());
+            }
             httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
             httpServletResponse.setCharacterEncoding("UTF-8");
             httpServletResponse.getWriter().write(jsonResponse);

--- a/src/main/java/com/gam/api/dto/user/response/UserDiscoveryResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/user/response/UserDiscoveryResponseDTO.java
@@ -30,7 +30,7 @@ record UserInfoVO(
 	public static UserInfoVO of(User user, boolean designerScrap){
 		return UserInfoVO.builder()
 				.userId(user.getId())
-				.userTag(user.getTags())
+				.userTag(user.getTags() == null ? new int[0] : user.getTags())
 				.userName(user.getUserName())
 				.viewCount(user.getViewCount())
 				.userDetail(user.getDetail())

--- a/src/main/java/com/gam/api/dto/user/response/UserMyProfileResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/user/response/UserMyProfileResponseDTO.java
@@ -20,7 +20,7 @@ public record UserMyProfileResponseDTO(
                 .info(user.getInfo())
                 .detail(user.getDetail())
                 .email(user.getEmail())
-                .userTag(user.getTags())
+                .userTag(user.getTags() == null ? new int[0] : user.getTags())
                 .build();
     }
 }

--- a/src/main/java/com/gam/api/dto/user/response/UserProfileResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/user/response/UserProfileResponseDTO.java
@@ -1,6 +1,7 @@
 package com.gam.api.dto.user.response;
 
 import com.gam.api.entity.User;
+import java.util.ArrayList;
 import lombok.Builder;
 
 @Builder
@@ -32,7 +33,7 @@ record UserProfileResponseVO(
                 .info(user.getInfo())
                 .detail(user.getDetail())
                 .email(user.getEmail())
-                .userTag(user.getTags())
+                .userTag(user.getTags() == null ? new int[0] : user.getTags())
                 .build();
     }
 }

--- a/src/main/java/com/gam/api/dto/user/response/UserResponseDTO.java
+++ b/src/main/java/com/gam/api/dto/user/response/UserResponseDTO.java
@@ -20,7 +20,7 @@ public record UserResponseDTO(
                 .userName(user.getUserName())
                 .userWorkThumbNail(Objects.isNull(user.getWorkThumbNail()) ? "" : user.getWorkThumbNail())
                 .viewCount(user.getViewCount())
-                .userTag(user.getTags())
+                .userTag(user.getTags() == null ? new int[0] : user.getTags())
                 .designerScrap(designerScrap)
                 .build();
     }

--- a/src/main/java/com/gam/api/service/user/UserDetailsServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserDetailsServiceImpl.java
@@ -26,13 +26,13 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     public UserDetails loadUserByUsername(String userId) {
         List<GrantedAuthority> authorities = new ArrayList<>();
         val user = userRepository.findById(Long.parseLong(userId))
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.TOKEN_USER_EXCEPTION.getMessage()));
 
         val userRole = user.getRole();
         val userStatus = user.getUserStatus();
 
         val authUser = authProviderRepository.searchAuthProviderByUser(user)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_USER.getMessage()));
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.TOKEN_USER_EXCEPTION.getMessage()));
 
         val authUserId = String.valueOf(authUser.getId());
 

--- a/src/main/java/com/gam/api/service/user/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/service/user/UserServiceImpl.java
@@ -217,6 +217,7 @@ public class UserServiceImpl implements UserService {
         if(Objects.nonNull(userScrap)){
             return UserProfileResponseDTO.of(userScrap.isStatus(), user);
         }
+        System.out.println(user.getTags());
         return UserProfileResponseDTO.of(false, user);
     }
 


### PR DESCRIPTION
## Related Issue 🚀
- #143 
## Work Description ✏️
- userTag의 리턴값이 현재 null일 경우 ""로 들어오고 있습니다. null to Empty list로 관련 에러를 수정 했습니다!
- 인기 유저 보기 /api/v1/user/popular
- 마이페이지 - 유저 프로필 보기 /api/v1/user/my/profile
- 발견 - 유저 /api/v1/user?tags=1&tags=2
- 발견 유저-프로필보기 /api/v1/user/detail/profile?userId={userId}

- 시큐리티 고쳤어욤 
- Token에서 NotFoundUser 처리 시에, Handler에서 잡지 못하고 있습니다. 아주 잘 잡혀용

