### PR TITLE
[FIX] 매거진 수정 api 변경, @Valid 적용, domain/s3로 폴더링 변경 

### DIFF
--- a/src/main/java/com/gam/api/common/ErrorHandler.java
+++ b/src/main/java/com/gam/api/common/ErrorHandler.java
@@ -33,7 +33,7 @@ public class ErrorHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception){
-        ApiResponse response = ApiResponse.fail(EMPTY_METHOD_ARGUMENT.getMessage());
+        ApiResponse response = ApiResponse.fail(exception.getBindingResult().getAllErrors().get(0).getDefaultMessage());
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/gam/api/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/gam/api/domain/admin/controller/AdminController.java
@@ -6,6 +6,7 @@ import com.gam.api.domain.admin.dto.magazine.request.MagazineRequestDTO;
 import com.gam.api.domain.user.entity.GamUserDetails;
 import com.gam.api.domain.admin.service.AdminService;
 import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
@@ -50,7 +51,7 @@ public class AdminController {
 
     @ApiOperation(value = "매거진 - 수정")
     @PatchMapping("/magazine/{magazineId}")
-    public ResponseEntity<ApiResponse> editMagazine(@PathVariable Long magazineId, @RequestBody MagazineRequestDTO request) {
+    public ResponseEntity<ApiResponse> editMagazine(@PathVariable Long magazineId, @Valid @RequestBody MagazineRequestDTO request) {
         adminService.editMagazine(magazineId, request);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_EDIT_MAGAZINE.getMessage()));
     }

--- a/src/main/java/com/gam/api/domain/admin/dto/magazine/request/MagazineRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/admin/dto/magazine/request/MagazineRequestDTO.java
@@ -11,7 +11,6 @@ public record MagazineRequestDTO(
         @NotBlank(message = "magazine title은 빈스트링 일 수 없습니다.")
         String title,
         @NotNull(message = "magazine photo는 null일 수 없습니다.")
-        @NotBlank(message = "magazine title은 빈스트링 일 수 없습니다.")
         List<String> magazinePhotos,
         @NotNull(message = "magazine intro는 null일 수 없습니다.")
         @NotBlank(message = "magazine intro는 빈스트링 일 수 없습니다.")
@@ -20,7 +19,6 @@ public record MagazineRequestDTO(
         @NotBlank(message = "magazine interviewPerson은 빈스트링 일 수 없습니다.")
         String interviewPerson,
         @NotNull(message = "magazine questions는 null일 수 없습니다.")
-        @NotBlank(message = "magazine questions는 빈스트링 일 수 없습니다.")
         List<QuestionVO> questions
 ) {
     @Builder

--- a/src/main/java/com/gam/api/domain/admin/dto/magazine/request/MagazineRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/admin/dto/magazine/request/MagazineRequestDTO.java
@@ -7,20 +7,20 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 
 public record MagazineRequestDTO(
-        @NotNull
-        @NotBlank
+        @NotNull(message = "magazine title은 null일 수 없습니다.")
+        @NotBlank(message = "magazine title은 빈스트링 일 수 없습니다.")
         String title,
-        @NotNull
-        @NotBlank
+        @NotNull(message = "magazine photo는 null일 수 없습니다.")
+        @NotBlank(message = "magazine title은 빈스트링 일 수 없습니다.")
         List<String> magazinePhotos,
-        @NotNull
-        @NotBlank
+        @NotNull(message = "magazine intro는 null일 수 없습니다.")
+        @NotBlank(message = "magazine intro는 빈스트링 일 수 없습니다.")
         String magazineIntro,
-        @NotNull
-        @NotBlank
+        @NotNull(message = "magazine interviewPerson은 null일 수 없습니다.")
+        @NotBlank(message = "magazine interviewPerson은 빈스트링 일 수 없습니다.")
         String interviewPerson,
-        @NotNull
-        @NotBlank
+        @NotNull(message = "magazine questions는 null일 수 없습니다.")
+        @NotBlank(message = "magazine questions는 빈스트링 일 수 없습니다.")
         List<QuestionVO> questions
 ) {
     @Builder

--- a/src/main/java/com/gam/api/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/admin/service/AdminServiceImpl.java
@@ -95,7 +95,9 @@ public class AdminServiceImpl implements AdminService {
             for (int i = 0; i < requestQuestionSize; i++) {
                 updateQuestionDetails(currentQuestions.get(i), request.questions().get(i));
             }
-            magazine.getQuestions().removeAll(currentQuestions.subList(request.questions().size(), currentQuestions.size()));
+            if(requestQuestionSize < currentQuestions.size()) {
+                magazine.getQuestions().removeAll(currentQuestions.subList(request.questions().size(), currentQuestions.size()));
+            }
             return;
         }
 

--- a/src/main/java/com/gam/api/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/admin/service/AdminServiceImpl.java
@@ -116,9 +116,10 @@ public class AdminServiceImpl implements AdminService {
         oldQuestion.setImageCaption(newQuestion.imageCaption());
     }
 
-    private List<Question> toQuestionEntity(Magazine magazine, List<QuestionVO> request) {
-        return request.stream()
-                .map((questionVO) -> {
+    @Transactional
+    public void toQuestionEntity(Magazine magazine, List<QuestionVO> request) {
+        request.stream()
+                .forEach((questionVO) -> {
                     Question question = Question.builder()
                             .questionOrder(questionVO.questionOrder())
                             .question(questionVO.question())
@@ -133,8 +134,7 @@ public class AdminServiceImpl implements AdminService {
                         question.setImageCaption(questionVO.imageCaption());
                     }
                     question.setMagazine(magazine);
-                    return question;
-                }).collect(Collectors.toList());
+                });
     }
 
 

--- a/src/main/java/com/gam/api/domain/magazine/entity/Magazine.java
+++ b/src/main/java/com/gam/api/domain/magazine/entity/Magazine.java
@@ -60,8 +60,6 @@ public class Magazine extends TimeStamped {
 
     public void scrapCountDown(){ this.scrapCount -= 1; }
 
-    public void setQuestions(List<Question> questions) { this.questions = questions; }
-
     @Builder
     public Magazine(String thumbNail, String magazineTitle, String introduction, String interviewPerson) {
         this.thumbNail = thumbNail;

--- a/src/main/java/com/gam/api/domain/magazine/entity/Question.java
+++ b/src/main/java/com/gam/api/domain/magazine/entity/Question.java
@@ -70,4 +70,17 @@ public class Question extends TimeStamped {
     public int hashCode() {
         return Objects.hash(getQuestionOrder(), getQuestion(), getAnswer(), getAnswerImage(), getImageCaption());
     }
+
+    @Override
+    public String toString() {
+        return "Question{" +
+                "id=" + id +
+                ", magazine=" + magazine +
+                ", questionOrder=" + questionOrder +
+                ", question='" + question + '\'' +
+                ", answer='" + answer + '\'' +
+                ", answerImage='" + answerImage + '\'' +
+                ", imageCaption='" + imageCaption + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/gam/api/domain/report/dto/request/ReportCreateRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/report/dto/request/ReportCreateRequestDTO.java
@@ -5,8 +5,8 @@ import javax.validation.constraints.NotNull;
 
 public record ReportCreateRequestDTO (
         Long targetUserId,
-        @NotBlank
-        @NotNull
+        @NotBlank(message = "신고내용은 빈스트링일 수 없습니다.")
+        @NotNull(message = "신고내용은 null일 수 없습니다.")
         String content,
         Long workId
 ){

--- a/src/main/java/com/gam/api/domain/s3/controller/S3Controller.java
+++ b/src/main/java/com/gam/api/domain/s3/controller/S3Controller.java
@@ -1,8 +1,8 @@
-package com.gam.api.external.s3.controller;
+package com.gam.api.domain.s3.controller;
 
 import com.gam.api.common.message.ResponseMessage;
-import com.gam.api.external.s3.dto.request.PresignedRequestDTO;
-import com.gam.api.external.s3.service.S3ServiceImpl;
+import com.gam.api.domain.s3.dto.request.PresignedRequestDTO;
+import com.gam.api.domain.s3.service.S3ServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.val;

--- a/src/main/java/com/gam/api/domain/s3/dto/request/ImageDeleteRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/s3/dto/request/ImageDeleteRequestDTO.java
@@ -1,4 +1,4 @@
-package com.gam.api.external.s3.dto.request;
+package com.gam.api.domain.s3.dto.request;
 
 public record ImageDeleteRequestDTO(String fileName) {
 }

--- a/src/main/java/com/gam/api/domain/s3/dto/request/PresignedRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/s3/dto/request/PresignedRequestDTO.java
@@ -1,4 +1,4 @@
-package com.gam.api.external.s3.dto.request;
+package com.gam.api.domain.s3.dto.request;
 
 import java.util.List;
 

--- a/src/main/java/com/gam/api/domain/s3/dto/response/PresignedResponseDTO.java
+++ b/src/main/java/com/gam/api/domain/s3/dto/response/PresignedResponseDTO.java
@@ -1,4 +1,4 @@
-package com.gam.api.external.s3.dto.response;
+package com.gam.api.domain.s3.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/gam/api/domain/s3/service/S3Service.java
+++ b/src/main/java/com/gam/api/domain/s3/service/S3Service.java
@@ -1,7 +1,7 @@
-package com.gam.api.external.s3.service;
+package com.gam.api.domain.s3.service;
 
-import com.gam.api.external.s3.dto.request.PresignedRequestDTO;
-import com.gam.api.external.s3.dto.response.PresignedResponseDTO;
+import com.gam.api.domain.s3.dto.request.PresignedRequestDTO;
+import com.gam.api.domain.s3.dto.response.PresignedResponseDTO;
 import java.util.List;
 
 public interface S3Service {

--- a/src/main/java/com/gam/api/domain/s3/service/S3ServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/s3/service/S3ServiceImpl.java
@@ -1,10 +1,10 @@
-package com.gam.api.external.s3.service;
+package com.gam.api.domain.s3.service;
 
 import com.gam.api.common.exception.AwsException;
 import com.gam.api.common.message.*;
 import com.gam.api.config.S3Config;
-import com.gam.api.external.s3.dto.request.PresignedRequestDTO;
-import com.gam.api.external.s3.dto.response.PresignedResponseDTO;
+import com.gam.api.domain.s3.dto.request.PresignedRequestDTO;
+import com.gam.api.domain.s3.dto.response.PresignedResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/gam/api/domain/user/dto/request/UserOnboardRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/user/dto/request/UserOnboardRequestDTO.java
@@ -2,13 +2,13 @@ package com.gam.api.domain.user.dto.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
 
 public record UserOnboardRequestDTO(
-        @NotBlank
-        @NotEmpty
+        @Size(min= 1, max= 15, message = "userName의 길이는 1글자 이상 15글자 이하여야 합니다.")
         String userName,
-        @NotBlank
-        @NotEmpty
+        @NotBlank(message = "info는 \"\"일 수 없습니다.")
+        @NotEmpty(message = "info는 null일 수 없습니다.")
         String info,
         @NotEmpty(message = "tags는 null일 수 없습니다, 하나 이상의 tag를 선택 해 주세요.")
         int[] tags

--- a/src/main/java/com/gam/api/domain/work/dto/request/WorkEditRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/work/dto/request/WorkEditRequestDTO.java
@@ -6,9 +6,9 @@ import javax.validation.constraints.NotBlank;
 
 public record WorkEditRequestDTO(
         Long workId,
-        @NotBlank
+        @NotBlank(message = "작업물 이미지를 추가해주세요")
         String image,
-        @NotBlank
+        @NotBlank(message = "작업물 제목은 빈스트링 일 수 없습니다.")
         String title,
         String detail
 ) {

--- a/src/main/java/com/gam/api/domain/work/service/WorkServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/work/service/WorkServiceImpl.java
@@ -13,7 +13,7 @@ import com.gam.api.domain.user.entity.UserStatus;
 import com.gam.api.domain.work.entity.Work;
 import com.gam.api.domain.user.repository.UserRepository;
 import com.gam.api.domain.work.repository.WorkRepository;
-import com.gam.api.external.s3.service.S3ServiceImpl;
+import com.gam.api.domain.s3.service.S3ServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;


### PR DESCRIPTION

## Related Issue 🚀
- #148 

## Work Description ✏️
- s3폴더 domain으로 이동했습니다!
- 기존 @valid로 잡은 에러 메시지를 명확하게 표기하도록 GlobalHandler에 추가했습니다.
- 매거진 수정 api를 변경했습니다. 

## PR Point 📸
- 매거진 수정 api 잘 봐주세요!

기존 
- 매거진 질문 개수 수정 x

변화 
- 매거진 질문 개수 수정 o 
