### PR TITLE
[FEAT] 봇 ip추적 intetceptor추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+	// logback
+	implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.9'
+	testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gam/api/config/WebMvcConfig.java
+++ b/src/main/java/com/gam/api/config/WebMvcConfig.java
@@ -1,10 +1,12 @@
 package com.gam.api.config;
 
+import com.gam.api.config.bot.PageNotFoundLogInterceptor;
 import com.gam.api.config.json.CustomObjectMapper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -23,6 +25,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter(customObjectMapper);
         converters.add(converter);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new PageNotFoundLogInterceptor());
     }
 }
 

--- a/src/main/java/com/gam/api/config/bot/PageNotFoundLogInterceptor.java
+++ b/src/main/java/com/gam/api/config/bot/PageNotFoundLogInterceptor.java
@@ -1,0 +1,44 @@
+package com.gam.api.config.bot;
+
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+public class PageNotFoundLogInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (response.getStatus() == 404) {
+            String ipAddress = getClientIP(request);
+            Object originalUri = request.getAttribute("javax.servlet.forward.request_uri");
+            String requestedUri = originalUri != null ? originalUri.toString() : "원본 URL을 확인할 수 없습니다.";
+
+            log.warn("IP Address " + ipAddress + " 접근 url " + requestedUri);
+        }
+        return true;
+    }
+
+    public static String getClientIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        if (ip == null) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+}

--- a/src/main/java/com/gam/api/domain/util/controller/UtilController.java
+++ b/src/main/java/com/gam/api/domain/util/controller/UtilController.java
@@ -1,19 +1,22 @@
-package com.gam.api.domain.test.controller;
+package com.gam.api.domain.util.controller;
 
 import com.gam.api.common.ApiResponse;
 import io.swagger.annotations.ApiOperation;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-
+@Slf4j
 @RestController
 @RequiredArgsConstructor
-public class TestController {
+public class UtilController {
     private final Environment env;
 
     @ApiOperation(value = "heal-check 컨트롤러")
@@ -21,4 +24,17 @@ public class TestController {
     public ResponseEntity<ApiResponse> test() {
         return ResponseEntity.ok(ApiResponse.success("Hello gam Server!"));
     }
+
+    @GetMapping(value = "/robots.txt")
+    @ResponseBody
+    public void robotsBlock(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            response.getWriter().write("User-agent: *\nDisallow: /\n");
+        } catch (IOException e) {
+            log.info("exception", e);
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/gam/api/domain/util/controller/UtilController.java
+++ b/src/main/java/com/gam/api/domain/util/controller/UtilController.java
@@ -34,7 +34,4 @@ public class UtilController {
             log.info("exception", e);
         }
     }
-
-
-
 }


### PR DESCRIPTION
## Related Issue 🚀
- #157 

## Work Description ✏️
- 봇 ip를 확인하고, 허용 ip를 구분짓기 위하여 404요청이 발생했을 경우, log.warn으로 해당 ip를 출력합니다.
- 현재는 파일로는 저장하지 않고 있고, 일차적으로 차단을 한 후에 logback을 이용하여 파일로 관리할 예정입니다. 

