### PR TITLE
[FEAT🛠️] 탈퇴 계정 재로그인 시 유저 상태 permitted로 변경

### DIFF
--- a/src/main/java/com/gam/api/domain/social/service/SocialCommonServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/social/service/SocialCommonServiceImpl.java
@@ -43,6 +43,7 @@ public class SocialCommonServiceImpl implements SocialCommonService {
         user.updateDeviceToken(deviceToken);
     }
 
+    @Transactional
     private SocialLoginResponseDTO reLogin(User user, String deviceToken) {
         val userId = user.getId();
         val accessToken = jwtTokenManager.createAccessToken(userId);
@@ -51,6 +52,10 @@ public class SocialCommonServiceImpl implements SocialCommonService {
         RedisUtil.saveRefreshToken(redisTemplate, refreshToken, userId);
 
         saveDeviceToken(user, deviceToken);
+
+        if (user.getUserStatus() == UserStatus.WITHDRAWAL) {
+            user.setUserStatus(UserStatus.PERMITTED);
+        }
 
         val isProfileCompleted = chkProfileCompleted(user);
         return SocialLoginResponseDTO.of(isProfileCompleted, userId, accessToken, refreshToken, gamConfig.getAppVersion());


### PR DESCRIPTION
## Related Issue 🚀
- #159 

## Work Description ✏️
- 로그인 로직에 재로그인 시 유저 상태 변경 되도록 했습니다.

## PR Point 📸
간단하게 변경만 적어놨습니다.
