### PR TITLE
[FIX] 유저 신고 api 수정 

### DIFF
--- a/src/main/java/com/gam/api/common/ErrorHandler.java
+++ b/src/main/java/com/gam/api/common/ErrorHandler.java
@@ -4,6 +4,7 @@ package com.gam.api.common;
 import com.gam.api.common.exception.AuthException;
 import com.gam.api.common.exception.AwsException;
 import com.gam.api.common.exception.BlockException;
+import com.gam.api.common.exception.ReportException;
 import com.gam.api.common.exception.ScrapException;
 import com.gam.api.common.exception.WorkException;
 import org.springframework.http.HttpStatus;
@@ -63,6 +64,12 @@ public class ErrorHandler {
 
     @ExceptionHandler(ScrapException.class)
     public ResponseEntity<ApiResponse> ScrapException(ScrapException exception) {
+        ApiResponse response = ApiResponse.fail(exception.getMessage());
+        return new ResponseEntity<>(response, exception.getStatusCode());
+    }
+
+    @ExceptionHandler(ReportException.class)
+    public ResponseEntity<ApiResponse> ReportException(ReportException exception){
         ApiResponse response = ApiResponse.fail(exception.getMessage());
         return new ResponseEntity<>(response, exception.getStatusCode());
     }

--- a/src/main/java/com/gam/api/common/exception/ReportException.java
+++ b/src/main/java/com/gam/api/common/exception/ReportException.java
@@ -1,0 +1,9 @@
+package com.gam.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ReportException extends GamException {
+    public ReportException(String message, HttpStatus statusCode) {
+        super(message, statusCode);
+    }
+}

--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -53,6 +53,7 @@ public enum ExceptionMessage {
     INVALID_MAIN_PHOTOS_COUNT("메거진의 메인 사진의 개수는 최대 4장입니다."),
 
     /** Report **/
+    ALREADY_REPORT_USER("이미 신고 한 유저입니다. 신고 처리 진행중"),
     NOT_MATCH_DB_BLOCK_STATUS("DB의 userScrap 상태와, 보낸 userScrap 상태가 같지 않습니다.");
 
     private final String message;

--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -53,7 +53,7 @@ public enum ExceptionMessage {
     INVALID_MAIN_PHOTOS_COUNT("메거진의 메인 사진의 개수는 최대 4장입니다."),
 
     /** Report **/
-    ALREADY_REPORT_USER("이미 신고 한 유저입니다. 신고 처리 진행중"),
+    ALREADY_REPORTED_USER("이미 신고 한 유저입니다. 신고 처리 진행중"),
     NOT_MATCH_DB_BLOCK_STATUS("DB의 userScrap 상태와, 보낸 userScrap 상태가 같지 않습니다.");
 
     private final String message;

--- a/src/main/java/com/gam/api/domain/report/controller/ReportController.java
+++ b/src/main/java/com/gam/api/domain/report/controller/ReportController.java
@@ -4,9 +4,11 @@ import com.gam.api.common.ApiResponse;
 import com.gam.api.common.message.ResponseMessage;
 import com.gam.api.domain.report.dto.request.ReportCreateRequestDTO;
 import com.gam.api.domain.report.service.ReportService;
+import com.gam.api.domain.user.entity.GamUserDetails;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -19,8 +21,9 @@ public class ReportController {
 
     @ApiOperation(value = "유저 신고")
     @PostMapping("")
-    public ResponseEntity<ApiResponse> createReport(@Valid @RequestBody ReportCreateRequestDTO request){
-     reportService.createReport(request);
+    public ResponseEntity<ApiResponse> createReport(@AuthenticationPrincipal GamUserDetails userDetails,
+                                                    @Valid @RequestBody ReportCreateRequestDTO request){
+     reportService.createReport(userDetails.getId(), request);
      return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_REPORT_USER.getMessage(), null));
     }
 }

--- a/src/main/java/com/gam/api/domain/report/dto/request/ReportCreateRequestDTO.java
+++ b/src/main/java/com/gam/api/domain/report/dto/request/ReportCreateRequestDTO.java
@@ -7,7 +7,6 @@ public record ReportCreateRequestDTO (
         Long targetUserId,
         @NotBlank(message = "신고내용은 빈스트링일 수 없습니다.")
         @NotNull(message = "신고내용은 null일 수 없습니다.")
-        String content,
-        Long workId
+        String content
 ){
 }

--- a/src/main/java/com/gam/api/domain/report/entity/Report.java
+++ b/src/main/java/com/gam/api/domain/report/entity/Report.java
@@ -35,22 +35,35 @@ public class Report extends TimeStamped {
     @JoinColumn(name = "target_user_id")
     private User targetUser;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User reportUser;
+
     @Column(name = "work_Id")
     private Long workId;
 
     @Builder
-    public Report(User targetUser, String content, Long workId){
+    public Report(User reportUser, User targetUser, String content, Long workId){
         this.status = ReportStatus.PROCEEDING;
-        setUser(targetUser);
+        setTargetUser(targetUser);
+        setReportUser(reportUser);
         this.content = content;
         this.workId = workId;
     }
 
-    private void setUser(User targetUser) {
+    private void setTargetUser(User targetUser) {
         if (Objects.nonNull(this.targetUser)) {
             this.targetUser.getReported().remove(this);
         }
         this.targetUser = targetUser;
         targetUser.getReported().add(this);
+    }
+
+    private void setReportUser(User reportUser) {
+        if (Objects.nonNull(this.reportUser)) {
+            this.reportUser.getReports().remove(this);
+        }
+        this.reportUser = reportUser;
+        reportUser.getReports().add(this);
     }
 }

--- a/src/main/java/com/gam/api/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/gam/api/domain/report/repository/ReportRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findAllByStatus(ReportStatus status);
     void deleteAllByTargetUserId(Long userId);
+
 }

--- a/src/main/java/com/gam/api/domain/report/service/ReportService.java
+++ b/src/main/java/com/gam/api/domain/report/service/ReportService.java
@@ -3,5 +3,5 @@ package com.gam.api.domain.report.service;
 import com.gam.api.domain.report.dto.request.ReportCreateRequestDTO;
 
 public interface ReportService {
-    void createReport(ReportCreateRequestDTO request);
+    void createReport(Long userId, ReportCreateRequestDTO request);
 }

--- a/src/main/java/com/gam/api/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/report/service/ReportServiceImpl.java
@@ -39,7 +39,7 @@ public class ReportServiceImpl implements ReportService{
                                     .collect(Collectors.toList());
 
         if(!reports.isEmpty()) {
-            throw new ReportException(ExceptionMessage.ALREADY_REPORT_USER.getMessage(), HttpStatus.BAD_REQUEST);
+            throw new ReportException(ExceptionMessage.ALREADY_REPORTED_USER.getMessage(), HttpStatus.BAD_REQUEST);
         }
 
         val report = Report.builder()

--- a/src/main/java/com/gam/api/domain/user/entity/User.java
+++ b/src/main/java/com/gam/api/domain/user/entity/User.java
@@ -102,8 +102,11 @@ public class User extends TimeStamped {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     List<Work> works = new ArrayList<>();
 
-    @OneToMany(mappedBy = "targetUser", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "targetUser", cascade = CascadeType.ALL) // 내가 신고 당한 'Report' 리스트
     private List<Report> reported;
+
+    @OneToMany(mappedBy = "reportUser") // 내가 신고한 'Report' 리스트
+    private List<Report> reports;
 
     @Type(type = "int-array")
     @Column(name = "tag",


### PR DESCRIPTION
## Related Issue 🚀
- #166 

## Work Description ✏️
- 유저 신고 api request수정 
- 유저 엔티티, 신고 엔티티 수정 


## PR Point 📸
- 기존의 엔티티 설계상 '신고 신청을 한 유저'가 저장되지 않았습니다. 
- 따라서 유저, 신고 엔티티에 '신고 신청을 한 유저'를 저장할 수 있게 구현했습니다. 