### PR TITLE
[FIX] 감잡은 디자이너 api수정 

### DIFF
--- a/src/main/java/com/gam/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/domain/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> getUserById(Long userId);
     boolean existsByUserName(String userName);
 
-    List<User> findByUserStatusOrderByScrapCountDesc(UserStatus userStatus); // TODO - 기획
+    List<User> findByUserStatusAndFirstWorkIdIsNotNullOrderByScrapCountDesc(UserStatus userStatus);
 
     @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")
     List<User> findByUserName(@Param("keyword") String keyword);

--- a/src/main/java/com/gam/api/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/user/service/UserServiceImpl.java
@@ -237,7 +237,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public List<UserResponseDTO> getPopularDesigners(Long userId) { //TODO - 쿼리 지연
-        val users = userRepository.findByUserStatusOrderByScrapCountDesc(UserStatus.PERMITTED);
+        val users = userRepository.findByUserStatusAndFirstWorkIdIsNotNullOrderByScrapCountDesc(UserStatus.PERMITTED);
 
         val me = findUser(userId);
         removeBlockUsers(users, me);


### PR DESCRIPTION
## Related Issue 🚀
- #185 

## Work Description ✏️
- 포토폴리오를 올린 유저만 볼 수 있게, api수정 했습니당

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 현재 대표작이(user->firstWorkId -> is not null) 이 있는 유저들만 갖고오게 수정해놨습니다.
-> work관련해서 work 삭제, 대표등록 모두 다 테스팅 해보고,  위의 로직으로 쿼리해도 이상이 없는거로 확인됐습니다!


close #185 
