### PR TITLE
[FEAT] Global Handler 및 Internal Server Error 슬랙 알림 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
+	// slack 알림
+	implementation 'com.slack.api:slack-api-client:1.27.2'
+
+	// slack DTO json Formatting
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gam/api/common/ApiResponse.java
+++ b/src/main/java/com/gam/api/common/ApiResponse.java
@@ -27,4 +27,9 @@ public record ApiResponse(boolean success, String message, Object data) {
                 .build();
     }
 
+    public static ApiResponse serverError(Object object){
+        return ApiResponse.builder()
+                .data(object)
+                .build();
+    }
 }

--- a/src/main/java/com/gam/api/common/ErrorHandler.java
+++ b/src/main/java/com/gam/api/common/ErrorHandler.java
@@ -35,14 +35,17 @@ public class ErrorHandler {
         val errorDTO = requestToDTO(exception, request);
         sendSlackAlarm(errorDTO.toString());
 
-        return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
+        ApiResponse response = ApiResponse.serverError(errorDTO);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Object> handleRuntimeException(RuntimeException exception, HttpServletRequest request) {
         val errorDTO = requestToDTO(exception, request);
         sendSlackAlarm(errorDTO.toString());
-        return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
+
+        ApiResponse response = ApiResponse.serverError(errorDTO);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 

--- a/src/main/java/com/gam/api/common/ErrorHandler.java
+++ b/src/main/java/com/gam/api/common/ErrorHandler.java
@@ -7,8 +7,12 @@ import com.gam.api.common.exception.BlockException;
 import com.gam.api.common.exception.ReportException;
 import com.gam.api.common.exception.ScrapException;
 import com.gam.api.common.exception.WorkException;
+import com.gam.api.common.message.ExceptionMessage;
+import com.gam.api.config.SlackConfig;
+import com.slack.api.Slack;
 import java.time.LocalDateTime;
 import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,26 +23,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import javax.persistence.EntityNotFoundException;
 
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class ErrorHandler {
+
+    private final Slack slack;
+    private final SlackConfig slackConfig;
 
     /** Internal Server Error + Slack Alert **/
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleException(Exception exception, HttpServletRequest request) {
-        val header = InternalServerErrorDTO.extractHeaders(request);
-
-        val errorDTO = InternalServerErrorDTO.of(header, request.getMethod(),  request.getRequestURL().toString(),
-                exception.getMessage(), exception.getClass().getName(), LocalDateTime.now());
+        val errorDTO = requestToDTO(exception, request);
+        sendSlackAlarm(errorDTO.toString());
 
         return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<Object> handleRuntimeException(RuntimeException exception, HttpServletRequest request) {
-        val header = InternalServerErrorDTO.extractHeaders(request);
-
-        val errorDTO = InternalServerErrorDTO.of(header, request.getMethod(),  request.getRequestURL().toString(),
-                exception.getMessage(), exception.getClass().getName(), LocalDateTime.now());
-
+        val errorDTO = requestToDTO(exception, request);
+        sendSlackAlarm(errorDTO.toString());
         return new ResponseEntity<>(errorDTO, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
@@ -96,6 +99,24 @@ public class ErrorHandler {
     public ResponseEntity<ApiResponse> ReportException(ReportException exception){
         ApiResponse response = ApiResponse.fail(exception.getMessage());
         return new ResponseEntity<>(response, exception.getStatusCode());
+    }
+
+    private InternalServerErrorDTO requestToDTO(Exception exception, HttpServletRequest request) {
+        val header = InternalServerErrorDTO.extractHeaders(request);
+        return InternalServerErrorDTO.of(header, request.getMethod(),  request.getRequestURL().toString(),
+                exception.getMessage(), exception.getClass().getName(), LocalDateTime.now());
+    }
+
+    private void sendSlackAlarm(String dto) {
+        try{
+            val slackResponse = slack.send(slackConfig.getUrl(), SlackErrorPayload.of(dto)).getBody();
+
+            if(!slackResponse.equals("ok")) {
+                throw new Exception(ExceptionMessage.NOT_POST_SLACK_ALARM.getMessage());// todo log -> 슬랙알림 안감
+            }
+        }catch (Exception exception) {
+            System.out.println(exception.toString()); // todo log
+        }
     }
 
 }

--- a/src/main/java/com/gam/api/common/InternalServerErrorDTO.java
+++ b/src/main/java/com/gam/api/common/InternalServerErrorDTO.java
@@ -1,8 +1,12 @@
 package com.gam.api.common;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Enumeration;
+import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +17,14 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class InternalServerErrorDTO {
-    private String header;
-    private String httpMethod;
-    private String URL;
-    private String message;
-    private String errorClass;
-    private String dateTime;
+    private String header = null;
+    private String httpMethod = null;
+    private String URL = null ;
+    private String message = null;
+
+    private String errorClass = null;
+
+    private String dateTime = "";
 
     @Builder
     private InternalServerErrorDTO(String header, String httpMethod, String URL, String message,
@@ -33,6 +39,9 @@ public class InternalServerErrorDTO {
 
     public static InternalServerErrorDTO of(String header, String httpMethod, String URL, String message,
                                             String errorClass, LocalDateTime nowDateTime) {
+        if(Objects.isNull(nowDateTime)) {
+            nowDateTime = LocalDateTime.now();
+        }
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String now = nowDateTime.format(formatter);
 
@@ -52,8 +61,22 @@ public class InternalServerErrorDTO {
         while (headerNames.hasMoreElements()) {
             String headerName = headerNames.nextElement();
             String headerValue = request.getHeader(headerName);
-            headers.append(headerName).append(": ").append(headerValue).append("    ");
+            headers.append(headerName).append(": ").append(headerValue);
         }
         return headers.toString();
     }
+
+    @Override
+    public String toString() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
+        String jsonString = null;
+        try {
+            jsonString = writer.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e); //todo Log
+        }
+        return jsonString;
+    }
+
 }

--- a/src/main/java/com/gam/api/common/InternalServerErrorDTO.java
+++ b/src/main/java/com/gam/api/common/InternalServerErrorDTO.java
@@ -1,0 +1,59 @@
+package com.gam.api.common;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class InternalServerErrorDTO {
+    private String header;
+    private String httpMethod;
+    private String URL;
+    private String message;
+    private String errorClass;
+    private String dateTime;
+
+    @Builder
+    private InternalServerErrorDTO(String header, String httpMethod, String URL, String message,
+                                   String errorClass, String dateTime) {
+        this.header = header;
+        this.httpMethod = httpMethod;
+        this.URL = URL;
+        this.message = message;
+        this.errorClass = errorClass;
+        this.dateTime = dateTime;
+    }
+
+    public static InternalServerErrorDTO of(String header, String httpMethod, String URL, String message,
+                                            String errorClass, LocalDateTime nowDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String now = nowDateTime.format(formatter);
+
+        return InternalServerErrorDTO.builder()
+                .header(header)
+                .httpMethod(httpMethod)
+                .URL(URL)
+                .message(message)
+                .errorClass(errorClass)
+                .dateTime(now)
+                .build();
+    }
+
+    public static String extractHeaders(HttpServletRequest request) {
+        StringBuilder headers = new StringBuilder();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            String headerValue = request.getHeader(headerName);
+            headers.append(headerName).append(": ").append(headerValue).append("    ");
+        }
+        return headers.toString();
+    }
+}

--- a/src/main/java/com/gam/api/common/SlackErrorPayload.java
+++ b/src/main/java/com/gam/api/common/SlackErrorPayload.java
@@ -1,0 +1,35 @@
+package com.gam.api.common;
+
+import static com.slack.api.model.block.Blocks.section;
+import static com.slack.api.model.block.composition.BlockCompositions.markdownText;
+import static java.util.Arrays.asList;
+
+import com.slack.api.webhook.Payload;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SlackErrorPayload {
+
+    private Payload payload;
+
+    @Builder
+    private SlackErrorPayload(Payload payload) {
+        this.payload = payload;
+    }
+
+    public static Payload of(String errorDto) {
+        // Create Payload with a code block
+        String codeBlock = "```\n" +errorDto +  "```";
+
+        return Payload.builder()
+                .blocks(asList(
+                        section(s -> s.text(markdownText(mt -> mt.text(codeBlock))))
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/gam/api/common/message/ExceptionMessage.java
+++ b/src/main/java/com/gam/api/common/message/ExceptionMessage.java
@@ -54,7 +54,10 @@ public enum ExceptionMessage {
 
     /** Report **/
     ALREADY_REPORTED_USER("이미 신고 한 유저입니다. 신고 처리 진행중"),
-    NOT_MATCH_DB_BLOCK_STATUS("DB의 userScrap 상태와, 보낸 userScrap 상태가 같지 않습니다.");
+    NOT_MATCH_DB_BLOCK_STATUS("DB의 userScrap 상태와, 보낸 userScrap 상태가 같지 않습니다."),
+
+    /** slack **/
+    NOT_POST_SLACK_ALARM("슬랙 알림이 전송되지 않았습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/gam/api/config/SlackConfig.java
+++ b/src/main/java/com/gam/api/config/SlackConfig.java
@@ -1,0 +1,20 @@
+package com.gam.api.config;
+
+import com.slack.api.Slack;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class SlackConfig {
+
+    @Value("${slack.url}")
+    private String url;
+
+    @Bean
+    public Slack slack() {
+        return Slack.getInstance();
+    }
+}


### PR DESCRIPTION
## Related Issue 🚀
- #187 

## Work Description ✏️
- RuntimeException과, 슬랙 알림 Exception을 잡습니다. 
- 클라이언트가 받을 response규격을 고려해서, 기존과 500에러 response틀을 맞추고자 합니다.
<img width="813" alt="스크린샷 2024-06-09 오후 6 52 07" src="https://github.com/Gam-develop/gam-server/assets/77230391/4bb8e276-b018-40e9-8973-d646a17c49af">
<br>
-> slack알림은 에러 메시지만 받습니다! <br>

<img width="790" alt="스크린샷 2024-06-09 오후 6 52 28" src="https://github.com/Gam-develop/gam-server/assets/77230391/b76c2c58-604a-440b-bd52-c31c16b4b535">


## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- 에러 처리에 대한 로그도 잘 심어놔야 할 것 같아요,
- 현재 config와 common폴더에 추가해놨는데, 폴더 위치를 옮기거나 수정해야할 것 같아요! 좋은 의견 있으시다면 추천해주세욤~
- 500에러 처리에 추가적으로 필요한 데이터가 있다면 꼭 말씀해주세요!

close #187 