### PR TITLE
[FEAT] 쿼리 개선 1차 작업

### DIFF
--- a/src/main/java/com/gam/api/ApiApplication.java
+++ b/src/main/java/com/gam/api/ApiApplication.java
@@ -2,7 +2,6 @@ package com.gam.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class ApiApplication {

--- a/src/main/java/com/gam/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/gam/api/domain/user/controller/UserController.java
@@ -62,7 +62,7 @@ public class UserController {
             @AuthenticationPrincipal GamUserDetails userDetails,
             @PathVariable Long userId)
     {
-        val response = userService.getPortfolio(userDetails.getId(), userId);
+        val response = userService.getPortfolio(userDetails.getUser(), userId);
         return ResponseEntity.ok(ApiResponse.success(ResponseMessage.SUCCESS_GET_PROTFOLIO_LIST.getMessage(), response));
     }
 

--- a/src/main/java/com/gam/api/domain/user/entity/GamUserDetails.java
+++ b/src/main/java/com/gam/api/domain/user/entity/GamUserDetails.java
@@ -11,7 +11,9 @@ import java.util.List;
 @Getter
 public class GamUserDetails implements UserDetails {
 
+    // TODO: User 객체 이전 이후 삭제 필요
     private final Long id;
+    private final User user;
     private final String username;
     private final String authUserId;
     private List<GrantedAuthority> authorities;
@@ -21,6 +23,11 @@ public class GamUserDetails implements UserDetails {
         return authorities;
     }
 
+    public User getUser() {
+        return user;
+    }
+
+    // TODO: User 객체 이전 이후 삭제 필요
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/gam/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gam/api/domain/user/repository/UserRepository.java
@@ -15,6 +15,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> getUserById(Long userId);
     boolean existsByUserName(String userName);
 
+    @Query("SELECT u FROM User u JOIN FETCH u.works WHERE u.id = :userId")
+    Optional<User> getUserByIdWithWorks(@Param("userId") Long userId);
+
     List<User> findByUserStatusAndFirstWorkIdIsNotNullOrderByScrapCountDesc(UserStatus userStatus);
 
     @Query(value = "SELECT u FROM User u WHERE LOWER(u.userName) LIKE %:keyword% ORDER BY u.createdAt DESC")

--- a/src/main/java/com/gam/api/domain/user/repository/UserScrapRepository.java
+++ b/src/main/java/com/gam/api/domain/user/repository/UserScrapRepository.java
@@ -1,5 +1,6 @@
 package com.gam.api.domain.user.repository;
 
+import com.gam.api.domain.user.entity.User;
 import com.gam.api.domain.user.entity.UserScrap;
 import com.gam.api.domain.user.dto.query.UserScrapQueryDto;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +10,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
+    List<UserScrap> findUserScrapsByUserId(Long userId);
     UserScrap findByUser_idAndTargetId(Long userId, Long targetId);
+
+    UserScrap findByUserAndTargetId(User user, Long targetId);
 
     @Query("SELECT DISTINCT NEW com.gam.api.domain.user.dto.query.UserScrapQueryDto(us.id, us.modifiedAt, us.targetId) "+
             "FROM UserScrap us " +

--- a/src/main/java/com/gam/api/domain/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/user/service/UserDetailsServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
-
 import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +40,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
         return GamUserDetails.builder()
                 .id(user.getId())
+                .user(user)
                 .authUserId(authUserId)
                 .username(user.getUserName())
                 .authorities(authorities)

--- a/src/main/java/com/gam/api/domain/user/service/UserService.java
+++ b/src/main/java/com/gam/api/domain/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.gam.api.domain.user.dto.response.UserDiscoveryResponseDTO;
 import com.gam.api.domain.user.dto.response.UserResponseDTO;
 import com.gam.api.domain.user.dto.response.UserScrapsResponseDTO;
 import com.gam.api.domain.user.dto.response.SearchUserWorkDTO;
+import com.gam.api.domain.user.entity.User;
 import com.gam.api.domain.work.dto.response.WorkPortfolioGetResponseDTO;
 import com.gam.api.domain.work.dto.response.WorkPortfolioListResponseDTO;
 
@@ -32,7 +33,7 @@ public interface UserService {
     List<UserScrapsResponseDTO> getUserScraps(Long userId);
     List<UserResponseDTO> getPopularDesigners(Long userId);
     WorkPortfolioListResponseDTO getMyPortfolio(Long userId);
-    WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId);
+    WorkPortfolioGetResponseDTO getPortfolio(User requestUser, Long userId);
     List<UserDiscoveryResponseDTO> getDiscoveryUsers(Long userId, int[] tags);
     void updateInstagramLink(Long userId, UserUpdateLinkRequestDTO request);
     void updateBehanceLink(Long userId, UserUpdateLinkRequestDTO request);

--- a/src/main/java/com/gam/api/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gam/api/domain/user/service/UserServiceImpl.java
@@ -264,10 +264,7 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public WorkPortfolioGetResponseDTO getPortfolio(Long requestUserId, Long userId) {
-        // TODO: spring security에서 주입
-        val requestUser = findUser(requestUserId);
-
+    public WorkPortfolioGetResponseDTO getPortfolio(User requestUser, Long userId) {
         val user = findUserWithWorks(userId);
         user.setViewCount(user.getViewCount() + 1);
         val works = refineWorkList(user.getWorks());
@@ -278,12 +275,8 @@ public class UserServiceImpl implements UserService {
 
         workRepository.updateWorksViewCount(workIds);
 
-        // TODO: spring security에서 주입
-        val scrapList = requestUser.getUserScraps().stream()
-                .map(UserScrap::getTargetId)
-                .toList();
-
-        val isScraped = scrapList.contains(user.getId());
+        val userScrap = userScrapRepository.findByUserAndTargetId(requestUser, user.getId());
+        val isScraped = Objects.isNull(userScrap);
 
         return WorkPortfolioGetResponseDTO.of(isScraped, user, works);
     }

--- a/src/main/java/com/gam/api/domain/work/repository/WorkRepository.java
+++ b/src/main/java/com/gam/api/domain/work/repository/WorkRepository.java
@@ -1,7 +1,9 @@
 package com.gam.api.domain.work.repository;
 
 import com.gam.api.domain.work.entity.Work;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -18,4 +20,8 @@ public interface WorkRepository extends JpaRepository<Work, Long> {
     @Query(value = "SELECT w FROM Work w WHERE LOWER(w.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY w.createdAt DESC")
     List<Work> findByKeyword(String keyword);
     Optional<Work> findFirstByUserIdAndIsActiveOrderByCreatedAtDesc(Long userId, boolean isActive);
+
+    @Modifying
+    @Query("UPDATE Work w SET w.viewCount = w.viewCount + 1 WHERE w.id IN :ids")
+    void updateWorksViewCount(@Param("ids") List<Long> ids);
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- #189

## Work Description ✏️
- 쿼리 개선 작업을 진행하였습니다.
- 우선 문서화화 시간이 오래걸려서 API 한개 (포트폴리오 조회)만 작업하였고, 나머지는 문서화를 간소화하며 진행해보려고 합니다.
- 해당 링크 [문서](https://github.com/user-attachments/files/15971952/default.pdf)를 한번 확인해주세요!

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
- spring security에서 인증/인가를 마치고 유저 정보를 주입하는 부분이 있는데요, 기존에는 userId만 주입했었어서 유저 정보를 알기 위해 조회 쿼리를 서비스 로직단에서 한번 더 날렸어야 했었습니다. 
- 다만 이 유저 정보를 주입하는 과정에서 user에 대한 조회 쿼리가 진행되기 때문에 두번 중복 진행되는데요, 이러한 불필요한 쿼리를 방지하고자 AuthenticationPrincipal에 User 객체를 넣어주려고 합니다. 
- 괜찮으신지 검토 부탁드립니다. 우려된다면 우려할 수 있는 점은 User 객체가 꽤 사이즈가 크다는 것 인데요, 제 생각에는 나머지 oneToMany로 되어있는 변수들은 바로 load되지 않기 때문에 큰 문제는 없을 것이라고 생각합니다.   